### PR TITLE
adding KubernetesCluster tag to ASG

### DIFF
--- a/config/crd/bases/instance-manager-configmap.yaml
+++ b/config/crd/bases/instance-manager-configmap.yaml
@@ -177,6 +177,7 @@ data:
             PropagateAtLaunch: 'true'
           - Key: KubernetesCluster
             Value: !Ref ClusterName
+            PropagateAtLaunch: 'true'
         {{$strategy := .Spec.AwsUpgradeStrategy.Type | ToLower}}
         {{if (eq $strategy "rollingupdate")}}
         UpdatePolicy:

--- a/docs/04_instance-manager.yaml
+++ b/docs/04_instance-manager.yaml
@@ -795,6 +795,9 @@ data:
           - Key: !Sub 'kubernetes.io/cluster/${ClusterName}'
             Value: 'owned'
             PropagateAtLaunch: 'true'
+          - Key: KubernetesCluster
+            Value: !Ref ClusterName
+            PropagateAtLaunch: 'true'
         {{$strategy := .Spec.AwsUpgradeStrategy.Type | ToLower}}
         {{if (eq $strategy "rollingupdate")}}
         UpdatePolicy:


### PR DESCRIPTION
IG's Which are created by `instance-manager` is missing `KubernetesCluster` tag on IG