### PR TITLE
Support Spot Instances

### DIFF
--- a/api/v1alpha1/instancegroup_types.go
+++ b/api/v1alpha1/instancegroup_types.go
@@ -51,6 +51,7 @@ const (
 // +kubebuilder:printcolumn:name="Group Name",type="string",JSONPath=".status.activeScalingGroupName",description="instancegroup created scalinggroup name"
 // +kubebuilder:printcolumn:name="Provisioner",type="string",JSONPath=".spec.provisioner",description="instance group provisioner"
 // +kubebuilder:printcolumn:name="Strategy",type="string",JSONPath=".spec.strategy.type",description="instance group upgrade strategy"
+// +kubebuilder:printcolumn:name="Lifecycle",type="string",JSONPath=".status.lifecycle",description="instance group lifecycle spot/normal"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="time passed since instancegroup creation"
 type InstanceGroup struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -106,6 +107,7 @@ type EKSCFConfiguration struct {
 	VolSize            int32               `json:"volSize,omitempty"`
 	Subnets            []string            `json:"subnets,omitempty"`
 	BootstrapArguments string              `json:"bootstrapArguments,omitempty"`
+	SpotPrice          string              `json:"spotPrice,omitempty"`
 	Tags               []map[string]string `json:"tags,omitempty"`
 }
 
@@ -118,6 +120,8 @@ type InstanceGroupStatus struct {
 	ActiveScalingGroupName        string `json:"activeScalingGroupName,omitempty"`
 	NodesArn                      string `json:"nodesInstanceRoleArn,omitempty"`
 	StrategyResourceName          string `json:"strategyResourceName,omitempty"`
+	UsingSpotRecommendation       bool   `json:"usingSpotRecommendation"`
+	Lifecycle                     string `json:"lifecycle,omitempty"`
 }
 
 func (s *AwsUpgradeStrategy) GetCRDType() CRDUpgradeStrategy {
@@ -224,6 +228,22 @@ func (status *InstanceGroupStatus) SetCurrentMax(max int) {
 	status.CurrentMax = max
 }
 
+func (status *InstanceGroupStatus) GetUsingSpotRecommendation() bool {
+	return status.UsingSpotRecommendation
+}
+
+func (status *InstanceGroupStatus) SetUsingSpotRecommendation(condition bool) {
+	status.UsingSpotRecommendation = condition
+}
+
+func (status *InstanceGroupStatus) GetLifecycle() string {
+	return status.Lifecycle
+}
+
+func (status *InstanceGroupStatus) SetLifecycle(phase string) {
+	status.Lifecycle = phase
+}
+
 func (strategy *AwsUpgradeStrategy) GetType() string {
 	return strategy.Type
 }
@@ -254,6 +274,14 @@ func (conf *EKSCFConfiguration) GetKeyName() string {
 
 func (conf *EKSCFConfiguration) SetKeyName(keypairName string) {
 	conf.KeyPairName = keypairName
+}
+
+func (conf *EKSCFConfiguration) SetSpotPrice(price string) {
+	conf.SpotPrice = price
+}
+
+func (conf *EKSCFConfiguration) GetSpotPrice() string {
+	return conf.SpotPrice
 }
 
 func (conf *EKSCFConfiguration) GetImage() string {

--- a/config/crd/bases/instance-manager-configmap.yaml
+++ b/config/crd/bases/instance-manager-configmap.yaml
@@ -193,6 +193,10 @@ data:
           ImageId: !Ref NodeImageId
           InstanceType: !Ref NodeInstanceType
           KeyName: !Ref KeyName
+          {{$spotPrice := .Spec.EKSCFSpec.EKSCFConfiguration.SpotPrice}}
+          {{if (ne $spotPrice "")}}
+          SpotPrice: {{$spotPrice}}
+          {{end}}
           SecurityGroups: !Ref NodeSecurityGroups
           BlockDeviceMappings:
             - DeviceName: /dev/xvda

--- a/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
+++ b/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
@@ -31,6 +31,10 @@ spec:
     description: instance group upgrade strategy
     name: Strategy
     type: string
+  - JSONPath: .status.lifecycle
+    description: instance group lifecycle spot/normal
+    name: Lifecycle
+    type: string
   - JSONPath: .metadata.creationTimestamp
     description: time passed since instancegroup creation
     name: Age
@@ -435,6 +439,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    spotPrice:
+                      type: string
                     subnets:
                       items:
                         type: string
@@ -506,10 +512,16 @@ spec:
               type: integer
             currentState:
               type: string
+            lifecycle:
+              type: string
             nodesInstanceRoleArn:
               type: string
             strategyResourceName:
               type: string
+            usingSpotRecommendation:
+              type: boolean
+          required:
+          - usingSpotRecommendation
           type: object
       required:
       - metadata

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -193,13 +193,12 @@ func GetScalingGroupTagsByName(name string, client autoscalingiface.AutoScalingA
 	if err != nil {
 		return tags, err
 	}
-	tags = out.AutoScalingGroups[0].Tags
 
-	if len(tags) < 1 {
+	if len(out.AutoScalingGroups) < 1 {
 		err := errors.New("could not find scaling group")
 		return tags, err
 	}
-
+	tags = out.AutoScalingGroups[0].Tags
 	return tags, nil
 }
 

--- a/controllers/provisioners/ekscloudformation/bootstrap.go
+++ b/controllers/provisioners/ekscloudformation/bootstrap.go
@@ -105,7 +105,7 @@ func (ctx *EksCfInstanceGroupContext) updateAuthConfigMap() error {
 		}
 	}
 
-	log.Infof("bootstrapping: %+v\n", newConfigurations)
+	log.Debugf("bootstrapping: %+v\n", newConfigurations)
 
 	d, err := yaml.Marshal(&newConfigurations.MapRoles)
 	if err != nil {

--- a/controllers/provisioners/ekscloudformation/ekscloudformation.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation.go
@@ -395,7 +395,6 @@ func (ctx *EksCfInstanceGroupContext) reloadDiscoveryCache() error {
 	ctx.discoverInstanceGroups()
 	discoveredInstanceGroups := discovery.GetInstanceGroups()
 
-	status.SetLifecycle("normal")
 	for _, group := range discoveredInstanceGroups.Items {
 		if group.StackName == ctx.AwsWorker.StackName {
 			status.SetActiveLaunchConfigurationName(group.LaunchConfigName)

--- a/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
@@ -925,7 +925,7 @@ func TestSpotInstancesRecommendationEnable(t *testing.T) {
 		getSpotSuggestionEvent("3", "my-asg", "0.006", true, time.Now().Add(time.Minute*time.Duration(5))),
 	}
 	testCase := EksCfUnitTest{
-		Description:       "Spot Instances - should take latest event's recommendation",
+		Description:       "Spot Instances - should take latest event's recommendation (enable)",
 		LoadCRD:           "rollingupgrade",
 		InstanceGroup:     instanceGroup,
 		StackExist:        true,
@@ -954,7 +954,7 @@ func TestSpotInstancesRecommendationDisable(t *testing.T) {
 		getSpotSuggestionEvent("2", "my-asg", "0.007", true, time.Now().Add(time.Minute*time.Duration(5))),
 	}
 	testCase := EksCfUnitTest{
-		Description:       "Spot Instances - should take latest event's recommendation",
+		Description:       "Spot Instances - should take latest event's recommendation (disable)",
 		LoadCRD:           "rollingupgrade",
 		InstanceGroup:     instanceGroup,
 		StackExist:        true,
@@ -979,7 +979,7 @@ func TestSpotInstancesManual(t *testing.T) {
 	instanceGroup.Status.ActiveScalingGroupName = "my-asg"
 	instanceGroup.Spec.EKSCFSpec.EKSCFConfiguration.SpotPrice = "0.005"
 	testCase := EksCfUnitTest{
-		Description:       "Spot Instances - should take latest event's recommendation",
+		Description:       "Spot Instances - should take user input from custom resource",
 		LoadCRD:           "rollingupgrade",
 		InstanceGroup:     instanceGroup,
 		StackExist:        true,

--- a/controllers/provisioners/ekscloudformation/spot.go
+++ b/controllers/provisioners/ekscloudformation/spot.go
@@ -48,15 +48,14 @@ func (ctx *EksCfInstanceGroupContext) discoverSpotPrice() {
 
 	// if no recommendations found
 	if reflect.DeepEqual(*recommendation, SpotRecommendation{}) {
-		// if it was using a recommendation before, set to false and reset price
+		// if it was using a recommendation before, set to false and leave price manually set
 		if status.GetUsingSpotRecommendation() {
 			status.SetUsingSpotRecommendation(false)
-			specConfig.SetSpotPrice("")
 		} else {
 			// if spotPrice is set without recommendation in custom resource
 			if specConfig.GetSpotPrice() != "" {
 				// keep custom resource provided value
-				log.Warnf("using manually set spot-price '%v', use a recommendations controller or risk losing all instances", specConfig.GetSpotPrice())
+				log.Warnf("using spot-price '%v' without recommendations, use a recommendations controller or risk losing all instances", specConfig.GetSpotPrice())
 			}
 		}
 		return

--- a/controllers/provisioners/ekscloudformation/spot.go
+++ b/controllers/provisioners/ekscloudformation/spot.go
@@ -1,0 +1,117 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ekscloudformation
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	SpotRecommendationReason  = "SpotRecommendationGiven"
+	SpotRecommendationVersion = "v1alpha1"
+)
+
+func (ctx *EksCfInstanceGroupContext) discoverSpotPrice() {
+	var (
+		instanceGroup     = ctx.GetInstanceGroup()
+		status            = &instanceGroup.Status
+		spec              = &instanceGroup.Spec
+		provisionerConfig = &spec.EKSCFSpec
+		specConfig        = &provisionerConfig.EKSCFConfiguration
+		scalingGroupName  = status.GetActiveScalingGroupName()
+	)
+
+	// get recommendations from events
+	recommendation, err := ctx.getLatestSpotRecommendation(scalingGroupName)
+	if err != nil {
+		specConfig.SetSpotPrice("")
+		return
+	}
+
+	// if no recommendations found
+	if reflect.DeepEqual(*recommendation, SpotRecommendation{}) {
+		// if it was using a recommendation before, set to false and reset price
+		if status.GetUsingSpotRecommendation() {
+			status.SetUsingSpotRecommendation(false)
+			specConfig.SetSpotPrice("")
+		} else {
+			// if spotPrice is set without recommendation in custom resource
+			if specConfig.GetSpotPrice() != "" {
+				// keep custom resource provided value
+				log.Warnf("using manually set spot-price '%v', use a recommendations controller or risk losing all instances", specConfig.GetSpotPrice())
+			}
+		}
+		return
+	}
+
+	if recommendation.APIVersion != SpotRecommendationVersion {
+		err := fmt.Sprintf("apiVersion '%v' is unknown", recommendation.APIVersion)
+		log.Warnf("failed to process spot recommendation, will override to on-demand: %v", err)
+	}
+
+	// process event message
+	status.SetUsingSpotRecommendation(true)
+
+	if recommendation.UseSpot {
+		log.Infof("spot enabled with current bid: %v", recommendation.SpotPrice)
+		specConfig.SetSpotPrice(recommendation.SpotPrice)
+	} else {
+		log.Infoln("use-spot is disabled")
+		specConfig.SetSpotPrice("")
+	}
+	ctx.reloadCloudformationConfiguration()
+}
+
+func (ctx *EksCfInstanceGroupContext) getLatestSpotRecommendation(scalingGroupName string) (*SpotRecommendation, error) {
+	var recommendations SpotReccomendations
+
+	fieldSelector := fmt.Sprintf("reason=%v,involvedObject.name=%v", SpotRecommendationReason, scalingGroupName)
+
+	listOpts := metav1.ListOptions{
+		FieldSelector: fieldSelector,
+	}
+
+	eventList, err := ctx.KubernetesClient.Kubernetes.CoreV1().Events("").List(listOpts)
+	if err != nil {
+		return &SpotRecommendation{}, err
+	}
+
+	for _, event := range eventList.Items {
+		recommendation := &SpotRecommendation{
+			EventTime: event.LastTimestamp.Time,
+		}
+		err := json.Unmarshal([]byte(event.Message), recommendation)
+		if err != nil {
+			return &SpotRecommendation{}, err
+		}
+		recommendations = append(recommendations, *recommendation)
+	}
+	sort.Sort(sort.Reverse(recommendations))
+
+	if len(recommendations) < 1 {
+		return &SpotRecommendation{}, nil
+	}
+
+	latestRecommendation := &recommendations[0]
+
+	return latestRecommendation, nil
+
+}

--- a/controllers/provisioners/ekscloudformation/types.go
+++ b/controllers/provisioners/ekscloudformation/types.go
@@ -17,6 +17,7 @@ package ekscloudformation
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -54,6 +55,7 @@ type EksCfInstanceGroupContext struct {
 	KubernetesClient common.KubernetesClientSet
 	AwsWorker        aws.AwsWorker
 	DiscoveredState  *DiscoveredState
+	TemplatePath     string
 	StackExists      bool
 	InstanceArn      string
 	ControllerRegion string
@@ -230,4 +232,25 @@ func (d *DiscoveredInstanceGroup) GetARN() string {
 		return d.ARN
 	}
 	return ""
+}
+
+type SpotRecommendation struct {
+	APIVersion string `yaml:"apiVersion"`
+	SpotPrice  string `yaml:"spotPrice"`
+	UseSpot    bool   `yaml:"useSpot"`
+	EventTime  time.Time
+}
+
+type SpotReccomendations []SpotRecommendation
+
+func (p SpotReccomendations) Len() int {
+	return len(p)
+}
+
+func (p SpotReccomendations) Less(i, j int) bool {
+	return p[i].EventTime.Before(p[j].EventTime)
+}
+
+func (p SpotReccomendations) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
 }

--- a/docs/04_instance-manager.yaml
+++ b/docs/04_instance-manager.yaml
@@ -35,6 +35,10 @@ spec:
     description: instance group upgrade strategy
     name: Strategy
     type: string
+  - JSONPath: .status.lifecycle
+    description: instance group lifecycle spot/normal
+    name: Lifecycle
+    type: string
   - JSONPath: .metadata.creationTimestamp
     description: time passed since instancegroup creation
     name: Age
@@ -439,6 +443,8 @@ spec:
                       items:
                         type: string
                       type: array
+                    spotPrice:
+                      type: string
                     subnets:
                       items:
                         type: string
@@ -510,10 +516,16 @@ spec:
               type: integer
             currentState:
               type: string
+            lifecycle:
+              type: string
             nodesInstanceRoleArn:
               type: string
             strategyResourceName:
               type: string
+            usingSpotRecommendation:
+              type: boolean
+          required:
+          - usingSpotRecommendation
           type: object
       required:
       - metadata
@@ -813,6 +825,10 @@ data:
           ImageId: !Ref NodeImageId
           InstanceType: !Ref NodeInstanceType
           KeyName: !Ref KeyName
+          {{$spotPrice := .Spec.EKSCFSpec.EKSCFConfiguration.SpotPrice}}
+          {{if (ne $spotPrice "")}}
+          SpotPrice: {{$spotPrice}}
+          {{end}}
           SecurityGroups: !Ref NodeSecurityGroups
           BlockDeviceMappings:
             - DeviceName: /dev/xvda

--- a/docs/README.md
+++ b/docs/README.md
@@ -386,6 +386,22 @@ There might be cases where you would want to implement custom behavior as part o
 
 In [this](./examples/crd-argo.yaml) example, we submit an [argo](https://github.com/argoproj/argo) workflow as a response to an upgrade events.
 
+#### Using spot instances
+
+You can switch to spot instances in two ways:
+
+- Manually set the `spec.eks-cf.configuration.spotPrice` to a spot price value, the downside is that if price becomes invalid (due to price changes) and instaces gets pulled, you may end up with no instances until you modify the price again.
+
+- Use a spot recommendation controller such as `minion-manager`, instance-manager will look at events with the following message format:
+
+```text
+{"apiVersion":"v1alpha1","spotPrice":"0.0067", "useSpot": true}
+```
+
+In addition, the event `involvedObject.name`, must be the name of the autoscaling group to switch, and the event `.reason` must be `SpotRecommendationGiven`.
+
+When recommendations are not available (no events for an hour / recommendation controller is down), instance-group will switch back to on-demand.
+
 ### Clean up
 
 First, delete the instance group:

--- a/docs/README.md
+++ b/docs/README.md
@@ -400,7 +400,7 @@ You can switch to spot instances in two ways:
 
 In addition, the event `involvedObject.name`, must be the name of the autoscaling group to switch, and the event `.reason` must be `SpotRecommendationGiven`.
 
-When recommendations are not available (no events for an hour / recommendation controller is down), instance-group will switch back to on-demand.
+When recommendations are not available (no events for an hour / recommendation controller is down), instance-group will retain the last provided configuration, until a human either changes back to on-demand (by setting `spotPrice: ""`) or until recommendation events are found again.
 
 ### Clean up
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -390,11 +390,11 @@ In [this](./examples/crd-argo.yaml) example, we submit an [argo](https://github.
 
 You can switch to spot instances in two ways:
 
-- Manually set the `spec.eks-cf.configuration.spotPrice` to a spot price value, the downside is that if price becomes invalid (due to price changes) and instaces gets pulled, you may end up with no instances until you modify the price again.
+- Manually set the `spec.eks-cf.configuration.spotPrice` to a spot price value, the downside is that if price becomes invalid (due to price changes) and instances gets pulled, you may end up with no instances until you modify the price again.
 
 - Use a spot recommendation controller such as `minion-manager`, instance-manager will look at events with the following message format:
 
-```text
+```json
 {"apiVersion":"v1alpha1","spotPrice":"0.0067", "useSpot": true}
 ```
 

--- a/test-bdd/main_test.go
+++ b/test-bdd/main_test.go
@@ -24,11 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
+	awsprovider "github.com/keikoproj/instance-manager/controllers/providers/aws"
+	"github.com/keikoproj/instance-manager/test-bdd/testutil"
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
-	awsprovider "github.com/keikoproj/instance-manager/controllers/providers/aws"
-	"github.com/keikoproj/instance-manager/test-bdd/testutil"
 	"github.com/sirupsen/logrus"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/dynamic"


### PR DESCRIPTION
Fixes #35 

This PR adds support for spot-instances with the following implementation:

- Recommendation reconciler was added to controller to watch all events, and trigger a reconcile for any event that is with reason `SpotRecommendationGiven`, the reconciler will reverse lookup the scaling group name from the event's `involvedObject.Name`, and find the instance group name and namespace in order to trigger it's reconcile.
- aws client (asg) is now needed before context is created (for reverse lookup), we should refactor and move all of the `AwsWorker` object outside of context instead on a later PR.
- `spotPrice` can be set manually in the CR, but will always be overridden by recommendations when it exists
- when recommendations become unavailable instance group will switch back to on-demand
- recommendations must follow the format:
```text
# Event Message
{"apiVersion":"v1alpha1","spotPrice":"0.0067", "useSpot": true}
# Event involvedObject.Name = scaling group name
# Event reason = SpotRecommendationGiven
```

- Also added two additional `status` fields - `usingSpotRecommendations` and `lifecycle`, a printer column was also added for `lifecycle`.

## Testing
- Added unit tests to test recommendations-based and manual setting of spotPrice
- Manually tested create/update in various scenarios
