### PR TITLE
update aws-auth to 0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.20.19
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
-	github.com/keikoproj/aws-auth v0.0.0-20190903203752-40f0a783a042
+	github.com/keikoproj/aws-auth v0.0.0-20190910182258-c705a9d52f92
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.6.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62F
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/keikoproj/aws-auth v0.0.0-20190903203752-40f0a783a042 h1:7CAKNomEvhv6H4mXGEdUxFJZR/pJgmKAAXWasO/7PMY=
 github.com/keikoproj/aws-auth v0.0.0-20190903203752-40f0a783a042/go.mod h1:TFnlFnL0EzKnV3lFZM/pTR/w4e/81kVJ/yd2gDaQk08=
+github.com/keikoproj/aws-auth v0.0.0-20190910182258-c705a9d52f92 h1:HcsujbGJfEC+aM/L48VXtfQnmPY1DVS3t7ylJZOZoqo=
+github.com/keikoproj/aws-auth v0.0.0-20190910182258-c705a9d52f92/go.mod h1:TFnlFnL0EzKnV3lFZM/pTR/w4e/81kVJ/yd2gDaQk08=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/imdario/mergo
 github.com/jmespath/go-jmespath
 # github.com/json-iterator/go v1.1.7
 github.com/json-iterator/go
-# github.com/keikoproj/aws-auth v0.0.0-20190903203752-40f0a783a042
+# github.com/keikoproj/aws-auth v0.0.0-20190910182258-c705a9d52f92
 github.com/keikoproj/aws-auth/pkg/mapper
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
 github.com/konsorten/go-windows-terminal-sequences


### PR DESCRIPTION
This includes a fix to aws-auth to create a configmap if it doesnt already exist.
This is good to have in case the aws-auth cm does not exist by the time instance-manager needs to upsert.