### PR TITLE
Cloudformation Stack Prefixes

### DIFF
--- a/api/v1alpha1/instancegroup_types.go
+++ b/api/v1alpha1/instancegroup_types.go
@@ -177,6 +177,7 @@ type EKSCFConfiguration struct {
 
 // InstanceGroupStatus defines the schema of resource Status
 type InstanceGroupStatus struct {
+	StackName                     string `json:"stackName,omitempty"`
 	CurrentState                  string `json:"currentState,omitempty"`
 	CurrentMin                    int    `json:"currentMin,omitempty"`
 	CurrentMax                    int    `json:"currentMax,omitempty"`
@@ -254,6 +255,14 @@ func (status *InstanceGroupStatus) GetActiveLaunchConfigurationName() string {
 
 func (status *InstanceGroupStatus) SetActiveLaunchConfigurationName(name string) {
 	status.ActiveLaunchConfigurationName = name
+}
+
+func (status *InstanceGroupStatus) GetStackName() string {
+	return status.StackName
+}
+
+func (status *InstanceGroupStatus) SetStackName(name string) {
+	status.StackName = name
 }
 
 func (status *InstanceGroupStatus) GetActiveScalingGroupName() string {

--- a/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
+++ b/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
@@ -533,6 +533,8 @@ spec:
               type: string
             nodesInstanceRoleArn:
               type: string
+            stackName:
+              type: string
             strategyResourceName:
               type: string
             usingSpotRecommendation:

--- a/controllers/instancegroup_controller.go
+++ b/controllers/instancegroup_controller.go
@@ -18,6 +18,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -197,7 +198,17 @@ func (r *InstanceGroupReconciler) ReconcileEKSCF(instanceGroup *v1alpha.Instance
 		KubeDynamic: dynClient,
 	}
 
-	defaultConfiguration, err := ekscloudformation.LoadControllerConfiguration(instanceGroup, r.ControllerConfPath)
+	if _, err := os.Stat(r.ControllerConfPath); os.IsNotExist(err) {
+		log.Errorf("controller config file not found: %v", err)
+		return err
+	}
+
+	controllerConfig, err := common.ReadFile(r.ControllerConfPath)
+	if err != nil {
+		return err
+	}
+
+	defaultConfiguration, err := ekscloudformation.LoadControllerConfiguration(instanceGroup, controllerConfig)
 	if err != nil {
 		log.Errorf("failed to load controller configuration: %v", err)
 		return err

--- a/controllers/provisioners/ekscloudformation/helpers.go
+++ b/controllers/provisioners/ekscloudformation/helpers.go
@@ -102,21 +102,11 @@ func (ctx *EksCfInstanceGroupContext) reloadCloudformationConfiguration() error 
 	return nil
 }
 
-func LoadControllerConfiguration(ig *v1alpha1.InstanceGroup, configPath string) (EksCfDefaultConfiguration, error) {
+func LoadControllerConfiguration(ig *v1alpha1.InstanceGroup, controllerConfig []byte) (EksCfDefaultConfiguration, error) {
 	var defaultConfig EksCfDefaultConfiguration
 	var specConfig = &ig.Spec.EKSCFSpec.EKSCFConfiguration
 
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		log.Errorf("controller config file not found: %v", err)
-		return defaultConfig, err
-	}
-
-	controllerConfig, err := common.ReadFile(configPath)
-	if err != nil {
-		return defaultConfig, err
-	}
-
-	err = yaml.Unmarshal(controllerConfig, &defaultConfig)
+	err := yaml.Unmarshal(controllerConfig, &defaultConfig)
 	if err != nil {
 		return defaultConfig, err
 	}

--- a/controllers/provisioners/ekscloudformation/helpers.go
+++ b/controllers/provisioners/ekscloudformation/helpers.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	"github.com/keikoproj/instance-manager/controllers/common"
+	yaml "gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -96,8 +97,39 @@ func (ctx *EksCfInstanceGroupContext) reloadCloudformationConfiguration() error 
 	if err != nil {
 		return err
 	}
+
 	ctx.AwsWorker.TemplateBody = template
 	return nil
+}
+
+func LoadControllerConfiguration(ig *v1alpha1.InstanceGroup, configPath string) (EksCfDefaultConfiguration, error) {
+	var defaultConfig EksCfDefaultConfiguration
+	var specConfig = &ig.Spec.EKSCFSpec.EKSCFConfiguration
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		log.Errorf("controller config file not found: %v", err)
+		return defaultConfig, err
+	}
+
+	controllerConfig, err := common.ReadFile(configPath)
+	if err != nil {
+		return defaultConfig, err
+	}
+
+	err = yaml.Unmarshal(controllerConfig, &defaultConfig)
+	if err != nil {
+		return defaultConfig, err
+	}
+
+	if len(defaultConfig.DefaultSubnets) != 0 {
+		specConfig.SetSubnets(defaultConfig.DefaultSubnets)
+	}
+
+	if defaultConfig.EksClusterName != "" {
+		specConfig.SetClusterName(defaultConfig.EksClusterName)
+	}
+
+	return defaultConfig, nil
 }
 
 func LoadCloudformationConfiguration(ig *v1alpha1.InstanceGroup, path string) (string, error) {

--- a/controllers/provisioners/ekscloudformation/types.go
+++ b/controllers/provisioners/ekscloudformation/types.go
@@ -41,9 +41,10 @@ type EksCfInstanceGroupContext struct {
 }
 
 type EksCfDefaultConfiguration struct {
-	DefaultSubnets []string `yaml:"defaultSubnets,omitempty"`
-	EksClusterName string   `yaml:"defaultClusterName,omitempty"`
-	DefaultARNs    []string `yaml:"defaultArns,omitempty"`
+	StackNamePrefix string   `yaml:"stackNamePrefix,omitempty"`
+	DefaultSubnets  []string `yaml:"defaultSubnets,omitempty"`
+	EksClusterName  string   `yaml:"defaultClusterName,omitempty"`
+	DefaultARNs     []string `yaml:"defaultArns,omitempty"`
 }
 
 func (ctx *EksCfInstanceGroupContext) GetInstanceGroup() *v1alpha1.InstanceGroup {

--- a/docs/04_instance-manager.yaml
+++ b/docs/04_instance-manager.yaml
@@ -537,6 +537,8 @@ spec:
               type: string
             nodesInstanceRoleArn:
               type: string
+            stackName:
+              type: string
             strategyResourceName:
               type: string
             usingSpotRecommendation:

--- a/docs/examples/crd-argo.yaml
+++ b/docs/examples/crd-argo.yaml
@@ -10,7 +10,7 @@ spec:
       crdName: workflows
       statusJSONPath: .status.phase
       statusSuccessString: Succeeded
-      statusErrorString: Failed
+      statusFailureString: Failed
       concurrencyPolicy: Forbid
       spec: |
         apiVersion: argoproj.io/v1alpha1

--- a/test-bdd/templates/instance-group-crd.yaml
+++ b/test-bdd/templates/instance-group-crd.yaml
@@ -13,7 +13,7 @@ spec:
       crdName: rollingupgrades
       statusJSONPath: .status.currentStatus
       statusSuccessString: completed
-      statusErrorString: error
+      statusFailureString: error
       spec: |
         apiVersion: upgrademgr.keikoproj.io/v1alpha1
         kind: RollingUpgrade


### PR DESCRIPTION
Fixes #45 

This PR adds support for `stackNamePrefix` in the controller global config.
Created stack name is persisted in `.Status.StackName` and then only read from there.
Move `LoadControllerConfig` inside the provisioner as it's quite specific for the ekscf provisioner and that seem to make more sense inside rather then in the controller.

Future PRs will follow for documentation improvements and improvements to current unit tests which are becoming a bit brittle.

Tested this feature out manually with various scenarios, including changing the prefix and restarting the controller, everything works as expected since the stack name is now persisted in the status and is the source of truth for stack name