### PR TITLE
Fix rollingUpdate strategy being set

### DIFF
--- a/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
+++ b/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
@@ -439,6 +439,10 @@ spec:
                       items:
                         type: string
                       type: array
+                    metricsCollection:
+                      items:
+                        type: string
+                      type: array
                     securityGroups:
                       items:
                         type: string

--- a/controllers/provisioners/ekscloudformation/ekscloudformation.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation.go
@@ -176,7 +176,7 @@ func (ctx *EksCfInstanceGroupContext) IsUpgradeNeeded() bool {
 	selfGroup := discovery.GetSelfGroup()
 	drifted, err := ctx.AwsWorker.DetectScalingGroupDrift(selfGroup.ScalingGroupName)
 	if err != nil {
-		log.Errorln("failed to detect if upgrade is needed")
+		log.Errorf("failed to detect if upgrade is needed: %v", err)
 		return false
 	}
 	if drifted {

--- a/controllers/provisioners/ekscloudformation/ekscloudformation.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation.go
@@ -491,10 +491,10 @@ func (ctx *EksCfInstanceGroupContext) processParameters() error {
 	return nil
 }
 
-//getManagedPolicyARNs constructs managed policy arns
+// getManagedPolicyARNs constructs managed policy arns
 func getManagedPolicyARNs(pNames []string) string {
-	//This is for Managed Policy ARN list.
-	//First add the DEFAULT required policies to the list passed by user as part of custom resource
+	// This is for Managed Policy ARN list.
+	// First add the DEFAULT required policies to the list passed by user as part of custom resource
 	var managedPolicyARNs []string
 	requiredPolicies := []string{"AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly"}
 	policyPrefix := "arn:aws:iam::aws:policy/"

--- a/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
@@ -1274,9 +1274,9 @@ func TestGetNodeAutoScalingGroupMetrics(t *testing.T) {
 
 func TestParseCustomResourceYamlEmptyString(t *testing.T) {
 	empty, err := common.ParseCustomResourceYaml("")
-	if (len(empty.Object) > 0)  {
-		t.Fatalf("Expected ParseCustomResourceYaml to return Unstructured whose Unstructured.object is of length: 0 but" +
-			" instead object is of length %d", len(empty.Object));
+	if len(empty.Object) > 0 {
+		t.Fatalf("Expected ParseCustomResourceYaml to return Unstructured whose Unstructured.object is of length: 0 but"+
+			" instead object is of length %d", len(empty.Object))
 	}
 	if err != nil {
 		t.Fatal("Empty YAML string produces error")

--- a/controllers/provisioners/ekscloudformation/strategy.go
+++ b/controllers/provisioners/ekscloudformation/strategy.go
@@ -88,6 +88,10 @@ func (ctx *EksCfInstanceGroupContext) setRollingStrategyConfigurationDefaults() 
 		pauseTime             = strategyConfiguration.GetPauseTime()
 	)
 
+	if strings.ToLower(instanceGroup.Spec.AwsUpgradeStrategy.Type) != "rollingupdate" {
+		return
+	}
+
 	if maxBatchSize == 0 {
 		strategyConfiguration.SetMaxBatchSize(1)
 	}


### PR DESCRIPTION
Fixes #51 

This skips setting defaults for rollingUpdate if type is not rollingUpdate.
Added some other things that were missing