### PR TITLE
Support attach policy which doesn't has default aws policy prefix

### DIFF
--- a/controllers/provisioners/ekscloudformation/ekscloudformation.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation.go
@@ -28,6 +28,7 @@ import (
 	"github.com/keikoproj/instance-manager/controllers/common"
 	awsprovider "github.com/keikoproj/instance-manager/controllers/providers/aws"
 	"github.com/sirupsen/logrus"
+	"regexp"
 )
 
 var (
@@ -504,8 +505,14 @@ func getManagedPolicyARNs(pNames []string) string {
 	// Add the user supplied policy names if any
 	if len(pNames) != 0 {
 		for _, name := range pNames {
-			// Trim the prefix arn:aws:iam::aws:policy/ if user supplied entire ARN instead of just name
-			managedPolicyARNs = append(managedPolicyARNs, fmt.Sprintf("%s%s", policyPrefix, strings.TrimPrefix(name, policyPrefix)))
+			// Append to list directly if user supplied entire ARN of policy
+			// Notes some customized policies may have prefix like 'arn:aws:iam::{account_number}:policy/' instead of 'arn:aws:iam::aws:policy/'
+			match, _ := regexp.MatchString("^arn:aws:iam::(aws|\\d{12}):policy/", name)
+			if match {
+				managedPolicyARNs = append(managedPolicyARNs, name)
+			} else {
+				managedPolicyARNs = append(managedPolicyARNs, fmt.Sprintf("%s%s", policyPrefix, name))
+			}
 		}
 	}
 

--- a/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
+++ b/controllers/provisioners/ekscloudformation/ekscloudformation_test.go
@@ -1231,6 +1231,11 @@ func TestGetManagedPolicyARNs(t *testing.T) {
 			input:    []string{"arn:aws:iam::aws:policy/My-Managed-Policy-1"},
 			expected: "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy,arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy,arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly,arn:aws:iam::aws:policy/My-Managed-Policy-1",
 		},
+		{
+			testCase: "custom resource creation with managed policy arn with account number",
+			input:    []string{"arn:aws:iam::123456789012:policy/My-Managed-Policy-3"},
+			expected: "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy,arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy,arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly,arn:aws:iam::123456789012:policy/My-Managed-Policy-3",
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
Currently, attach managed policy only support policy with default aws prefix `arn:aws:iam::aws:policy/`. This change will support attach managed policy which has prefix `arn:aws:iam::{account_number}:policy/`