### PR TITLE
set RollingUpgradeStrategy if nil

### DIFF
--- a/api/v1alpha1/instancegroup_types.go
+++ b/api/v1alpha1/instancegroup_types.go
@@ -245,6 +245,9 @@ func (spec *EKSManagedSpec) GetMinSize() int64 {
 }
 
 func (s *AwsUpgradeStrategy) GetRollingUpgradeStrategy() *RollingUpgradeStrategy {
+	if s.RollingUpgradeType == nil{
+		s.RollingUpgradeType = &RollingUpgradeStrategy{}
+	}
 	return s.RollingUpgradeType
 }
 


### PR DESCRIPTION
Fixing Issue #81 
by setting RollingUpgradeStrategy object so that the template gets the default values set using setRollingStrategyConfigurationDefaults()