### PR TITLE
Pagination & Launch config deletion

### DIFF
--- a/controllers/common/utils.go
+++ b/controllers/common/utils.go
@@ -90,5 +90,5 @@ func ReadFile(path string) ([]byte, error) {
 
 func GetTimeString() string {
 	n := time.Now().UTC()
-	return fmt.Sprintf("%v%v%v%v%v%v", n.Year(), int(n.Month()), n.Day(), n.Hour(), n.Minute(), n.Second())
+	return n.Format("20060102150405")
 }

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -494,12 +494,16 @@ func (w *AwsWorker) DescribeAutoscalingGroups() ([]*autoscaling.Group, error) {
 	return scalingGroups, nil
 }
 
-func (w *AwsWorker) DescribeAutoscalingLaunchConfigs() (autoscaling.DescribeLaunchConfigurationsOutput, error) {
-	out, err := w.AsgClient.DescribeLaunchConfigurations(&autoscaling.DescribeLaunchConfigurationsInput{})
+func (w *AwsWorker) DescribeAutoscalingLaunchConfigs() ([]*autoscaling.LaunchConfiguration, error) {
+	launchConfigurations := []*autoscaling.LaunchConfiguration{}
+	err := w.AsgClient.DescribeLaunchConfigurationsPages(&autoscaling.DescribeLaunchConfigurationsInput{}, func(page *autoscaling.DescribeLaunchConfigurationsOutput, lastPage bool) bool {
+		launchConfigurations = append(launchConfigurations, page.LaunchConfigurations...)
+		return page.NextToken != nil
+	})
 	if err != nil {
-		return autoscaling.DescribeLaunchConfigurationsOutput{}, err
+		return launchConfigurations, err
 	}
-	return *out, nil
+	return launchConfigurations, nil
 }
 
 func (w *AwsWorker) GetAutoscalingLaunchConfig(name string) (*autoscaling.LaunchConfiguration, error) {

--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -17,6 +17,7 @@ package eks
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	kubeprovider "github.com/keikoproj/instance-manager/controllers/providers/kubernetes"
@@ -134,6 +135,10 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 
 	for _, d := range deletable {
 		name := aws.StringValue(d.LaunchConfigurationName)
+		if strings.EqualFold(name, state.GetActiveLaunchConfigurationName()) {
+			// never try to delete the active launch config
+			continue
+		}
 		ctx.Log.Info("deleting old launch configuration", "instancegroup", instanceGroup.GetName(), "name", name)
 		if err := ctx.AwsWorker.DeleteLaunchConfig(name); err != nil {
 			ctx.Log.Error(err, "failed to delete launch configuration", "instancegroup", instanceGroup.GetName(), "name", name)

--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -128,8 +128,8 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 	// delete old launch configurations
 	sortedConfigs := ctx.GetTimeSortedLaunchConfigurations()
 	var deletable []*autoscaling.LaunchConfiguration
-	if len(sortedConfigs) > launchConfigurationRetentionCount {
-		d := len(sortedConfigs) - launchConfigurationRetentionCount
+	if len(sortedConfigs) > defaultLaunchConfigurationRetention {
+		d := len(sortedConfigs) - defaultLaunchConfigurationRetention
 		deletable = sortedConfigs[:d]
 	}
 

--- a/controllers/provisioners/eks/create.go
+++ b/controllers/provisioners/eks/create.go
@@ -44,8 +44,7 @@ func (ctx *EksInstanceGroupContext) Create() error {
 	// create launchconfig
 	if !state.HasLaunchConfiguration() {
 		lcName := fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())
-		lcInput := ctx.GetLaunchConfigurationInput(lcName)
-		err := ctx.CreateLaunchConfiguration(lcInput)
+		err := ctx.CreateLaunchConfiguration(lcName)
 		if err != nil {
 			return errors.Wrap(err, "failed to create launch configuration")
 		}
@@ -101,12 +100,12 @@ func (ctx *EksInstanceGroupContext) CreateScalingGroup() error {
 	return nil
 }
 
-func (ctx *EksInstanceGroupContext) CreateLaunchConfiguration(input *autoscaling.CreateLaunchConfigurationInput) error {
+func (ctx *EksInstanceGroupContext) CreateLaunchConfiguration(name string) error {
 	var (
 		state         = ctx.GetDiscoveredState()
 		instanceGroup = ctx.GetInstanceGroup()
 		status        = instanceGroup.GetStatus()
-		name          = aws.StringValue(input.LaunchConfigurationName)
+		input         = ctx.GetLaunchConfigurationInput(name)
 	)
 
 	if aws.StringValue(input.IamInstanceProfile) == "" {

--- a/controllers/provisioners/eks/create.go
+++ b/controllers/provisioners/eks/create.go
@@ -43,7 +43,9 @@ func (ctx *EksInstanceGroupContext) Create() error {
 
 	// create launchconfig
 	if !state.HasLaunchConfiguration() {
-		err := ctx.CreateLaunchConfiguration()
+		lcName := fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())
+		lcInput := ctx.GetLaunchConfigurationInput(lcName)
+		err := ctx.CreateLaunchConfiguration(lcInput)
 		if err != nil {
 			return errors.Wrap(err, "failed to create launch configuration")
 		}
@@ -64,9 +66,8 @@ func (ctx *EksInstanceGroupContext) CreateScalingGroup() error {
 		instanceGroup = ctx.GetInstanceGroup()
 		spec          = instanceGroup.GetEKSSpec()
 		configuration = instanceGroup.GetEKSConfiguration()
-		clusterName   = configuration.GetClusterName()
 		state         = ctx.GetDiscoveredState()
-		asgName       = fmt.Sprintf("%v-%v-%v", clusterName, instanceGroup.GetNamespace(), instanceGroup.GetName())
+		asgName       = ctx.ResourcePrefix
 		tags          = ctx.GetAddedTags(asgName)
 	)
 
@@ -100,35 +101,30 @@ func (ctx *EksInstanceGroupContext) CreateScalingGroup() error {
 	return nil
 }
 
-func (ctx *EksInstanceGroupContext) CreateLaunchConfiguration() error {
+func (ctx *EksInstanceGroupContext) CreateLaunchConfiguration(input *autoscaling.CreateLaunchConfigurationInput) error {
 	var (
 		state         = ctx.GetDiscoveredState()
 		instanceGroup = ctx.GetInstanceGroup()
-		configuration = instanceGroup.GetEKSConfiguration()
 		status        = instanceGroup.GetStatus()
-		clusterName   = configuration.GetClusterName()
-		lcName        = fmt.Sprintf("%v-%v-%v-%v", clusterName, instanceGroup.GetNamespace(), instanceGroup.GetName(), common.GetTimeString())
-		lcInput       = ctx.GetLaunchConfigurationInput(lcName)
+		name          = aws.StringValue(input.LaunchConfigurationName)
 	)
 
-	if aws.StringValue(lcInput.IamInstanceProfile) == "" {
+	if aws.StringValue(input.IamInstanceProfile) == "" {
 		return errors.Errorf("cannot create a launchconfiguration without iam instance profile")
 	}
 
-	err := ctx.AwsWorker.CreateLaunchConfig(lcInput)
+	err := ctx.AwsWorker.CreateLaunchConfig(input)
 	if err != nil {
 		return err
 	}
 
-	ctx.Log.Info("created launchconfig", "instancegroup", instanceGroup.GetName(), "launchconfig", lcName)
-
-	lc, err := ctx.AwsWorker.GetAutoscalingLaunchConfig(lcName)
+	ctx.Log.Info("created launchconfig", "instancegroup", instanceGroup.GetName(), "launchconfig", name)
+	lc, err := ctx.AwsWorker.GetAutoscalingLaunchConfig(name)
 	if err != nil {
 		return err
 	}
 
 	if lc != nil {
-		name := aws.StringValue(lc.LaunchConfigurationName)
 		status.SetActiveLaunchConfigurationName(name)
 		state.SetActiveLaunchConfigurationName(name)
 		state.SetLaunchConfiguration(lc)
@@ -142,9 +138,8 @@ func (ctx *EksInstanceGroupContext) CreateManagedRole() error {
 		instanceGroup      = ctx.GetInstanceGroup()
 		state              = ctx.GetDiscoveredState()
 		configuration      = instanceGroup.GetEKSConfiguration()
-		clusterName        = configuration.GetClusterName()
 		additionalPolicies = configuration.GetManagedPolicies()
-		roleName           = fmt.Sprintf("%v-%v-%v", clusterName, instanceGroup.GetNamespace(), instanceGroup.GetName())
+		roleName           = ctx.ResourcePrefix
 	)
 
 	if configuration.HasExistingRole() {

--- a/controllers/provisioners/eks/delete.go
+++ b/controllers/provisioners/eks/delete.go
@@ -16,6 +16,8 @@ limitations under the License.
 package eks
 
 import (
+	"strings"
+
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	kubeprovider "github.com/keikoproj/instance-manager/controllers/providers/kubernetes"
 	"github.com/pkg/errors"
@@ -83,18 +85,18 @@ func (ctx *EksInstanceGroupContext) DeleteLaunchConfiguration() error {
 	var (
 		state         = ctx.GetDiscoveredState()
 		instanceGroup = ctx.GetInstanceGroup()
-		lcName        = state.GetActiveLaunchConfigurationName()
 	)
 
-	if !state.HasLaunchConfiguration() {
-		return nil
+	for _, lc := range state.GetLaunchConfigurations() {
+		name := aws.StringValue(lc.LaunchConfigurationName)
+		if strings.HasPrefix(name, ctx.ResourcePrefix) {
+			err := ctx.AwsWorker.DeleteLaunchConfig(name)
+			if err != nil {
+				return err
+			}
+			ctx.Log.Info("deleted launch config", "instancegroup", instanceGroup.GetName(), "launchconfig", name)
+		}
 	}
-
-	err := ctx.AwsWorker.DeleteLaunchConfig(lcName)
-	if err != nil {
-		return err
-	}
-	ctx.Log.Info("deleted launch config", "instancegroup", instanceGroup.GetName(), "launchconfig", lcName)
 	return nil
 }
 

--- a/controllers/provisioners/eks/delete_test.go
+++ b/controllers/provisioners/eks/delete_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package eks
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -104,14 +105,17 @@ func TestDeleteLaunchConfigurationNegative(t *testing.T) {
 		Publisher: kubeprovider.EventPublisher{
 			Client: k.Kubernetes,
 		},
-		LaunchConfiguration: &autoscaling.LaunchConfiguration{},
+		LaunchConfigurations: []*autoscaling.LaunchConfiguration{
+			{
+				LaunchConfigurationName: aws.String(fmt.Sprintf("%v-123456", ctx.ResourcePrefix)),
+			},
+		},
 	})
 
 	asgMock.DeleteLaunchConfigurationErr = errors.New("some-error")
 	err := ctx.Delete()
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(ctx.GetState()).To(gomega.Equal(v1alpha1.ReconcileDeleting))
-	asgMock.DeleteLaunchConfigurationErr = nil
 }
 
 func TestDeleteAutoScalingGroupNegative(t *testing.T) {

--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -16,6 +16,7 @@ limitations under the License.
 package eks
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -45,6 +46,8 @@ func New(p provisioners.ProvisionerInput) *EksInstanceGroupContext {
 	}
 	instanceGroup := ctx.GetInstanceGroup()
 	configuration := instanceGroup.GetEKSConfiguration()
+	ctx.ResourcePrefix = fmt.Sprintf("%v-%v-%v", configuration.GetClusterName(), instanceGroup.GetNamespace(), instanceGroup.GetName())
+
 	instanceGroup.SetState(v1alpha1.ReconcileInit)
 
 	if len(p.Configuration.DefaultSubnets) != 0 {
@@ -79,6 +82,7 @@ type EksInstanceGroupContext struct {
 	AwsWorker        awsprovider.AwsWorker
 	DiscoveredState  *DiscoveredState
 	Log              logr.Logger
+	ResourcePrefix   string
 }
 
 func (ctx *EksInstanceGroupContext) GetInstanceGroup() *v1alpha1.InstanceGroup {

--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	ProvisionerName = "eks"
+	ProvisionerName                     = "eks"
+	defaultLaunchConfigurationRetention = 2
 )
 
 var (

--- a/controllers/provisioners/eks/eks_test.go
+++ b/controllers/provisioners/eks/eks_test.go
@@ -259,6 +259,7 @@ type MockAutoScalingClient struct {
 	UpdateAutoScalingGroupErr              error
 	DeleteAutoScalingGroupErr              error
 	TerminateInstanceInAutoScalingGroupErr error
+	DeleteLaunchConfigurationCallCount     int
 	LaunchConfiguration                    *autoscaling.LaunchConfiguration
 	LaunchConfigurations                   []*autoscaling.LaunchConfiguration
 	AutoScalingGroup                       *autoscaling.Group
@@ -286,6 +287,7 @@ func (a *MockAutoScalingClient) DescribeLaunchConfigurations(input *autoscaling.
 }
 
 func (a *MockAutoScalingClient) DeleteLaunchConfiguration(input *autoscaling.DeleteLaunchConfigurationInput) (*autoscaling.DeleteLaunchConfigurationOutput, error) {
+	a.DeleteLaunchConfigurationCallCount++
 	return &autoscaling.DeleteLaunchConfigurationOutput{}, a.DeleteLaunchConfigurationErr
 }
 
@@ -303,6 +305,15 @@ func (a *MockAutoScalingClient) DescribeAutoScalingGroups(input *autoscaling.Des
 
 func (a *MockAutoScalingClient) DescribeAutoScalingGroupsPages(input *autoscaling.DescribeAutoScalingGroupsInput, callback func(*autoscaling.DescribeAutoScalingGroupsOutput, bool) bool) error {
 	page, err := a.DescribeAutoScalingGroups(input)
+	if err != nil {
+		return err
+	}
+	callback(page, false)
+	return nil
+}
+
+func (a *MockAutoScalingClient) DescribeLaunchConfigurationsPages(input *autoscaling.DescribeLaunchConfigurationsInput, callback func(*autoscaling.DescribeLaunchConfigurationsOutput, bool) bool) error {
+	page, err := a.DescribeLaunchConfigurations(input)
 	if err != nil {
 		return err
 	}

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -30,8 +30,6 @@ import (
 func (ctx *EksInstanceGroupContext) Update() error {
 	var (
 		instanceGroup  = ctx.GetInstanceGroup()
-		configuration  = instanceGroup.GetEKSConfiguration()
-		clusterName    = configuration.GetClusterName()
 		rotationNeeded bool
 	)
 

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -27,10 +27,6 @@ import (
 	"github.com/keikoproj/instance-manager/controllers/common"
 )
 
-const (
-	launchConfigurationRetentionCount = 2
-)
-
 func (ctx *EksInstanceGroupContext) Update() error {
 	var (
 		instanceGroup  = ctx.GetInstanceGroup()

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -46,7 +46,7 @@ func (ctx *EksInstanceGroupContext) Update() error {
 	// create new launchconfig if it has drifted
 	if ctx.LaunchConfigurationDrifted() {
 		rotationNeeded = true
-		lcName := fmt.Sprintf("%v-%v-%v-%v", clusterName, instanceGroup.GetNamespace(), instanceGroup.GetName(), common.GetTimeString())
+		lcName := fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())
 		lcInput := ctx.GetLaunchConfigurationInput(lcName)
 		err := ctx.CreateLaunchConfiguration(lcInput)
 		if err != nil {

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -45,8 +45,7 @@ func (ctx *EksInstanceGroupContext) Update() error {
 	if ctx.LaunchConfigurationDrifted() {
 		rotationNeeded = true
 		lcName := fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())
-		lcInput := ctx.GetLaunchConfigurationInput(lcName)
-		err := ctx.CreateLaunchConfiguration(lcInput)
+		err := ctx.CreateLaunchConfiguration(lcName)
 		if err != nil {
 			return errors.Wrap(err, "failed to create launch configuration")
 		}


### PR DESCRIPTION
Fixes #114 

This adds pagination for DescribeLaunchConfigurations and refactors create/update/delete to properly handle launch configuration deletion.

New logic will be called on CloudDiscovery instead of during update, and will delete the oldest launch configurations per instance group outside of the newest ones according to number of default retention (default 2) - we can make this configurable in the future.
IG Deletion now simply deletes all launch configs with the resource prefix.

- [x] BDD