### PR TITLE
Update instance-manager-deployment.yaml

### DIFF
--- a/config/crd/bases/instance-manager-deployment.yaml
+++ b/config/crd/bases/instance-manager-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
apiVersion changed from "extensions/v1beta1" to "apps/v1" to fix error: unable to recognize "instance-manager-deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"