### PR TITLE
AWS API Optimization - Create

### DIFF
--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -516,21 +516,6 @@ func (w *AwsWorker) DescribeAutoscalingLaunchConfigs() ([]*autoscaling.LaunchCon
 	return launchConfigurations, nil
 }
 
-func (w *AwsWorker) GetAutoscalingLaunchConfig(name string) (*autoscaling.LaunchConfiguration, error) {
-	var lc *autoscaling.LaunchConfiguration
-	out, err := w.AsgClient.DescribeLaunchConfigurations(&autoscaling.DescribeLaunchConfigurationsInput{})
-	if err != nil {
-		return lc, err
-	}
-	for _, config := range out.LaunchConfigurations {
-		n := aws.StringValue(config.LaunchConfigurationName)
-		if strings.EqualFold(name, n) {
-			lc = config
-		}
-	}
-	return lc, nil
-}
-
 func (w *AwsWorker) GetAutoscalingGroup(name string) (*autoscaling.Group, error) {
 	var asg *autoscaling.Group
 	out, err := w.AsgClient.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -317,13 +317,6 @@ func (w *AwsWorker) CreateUpdateScalingGroupRole(name string, managedPolicies []
 			return createdRole, createdProfile, errors.Wrap(err, "failed to create instance-profile")
 		}
 		createdProfile = out.InstanceProfile
-
-		err = w.IamClient.WaitUntilInstanceProfileExists(&iam.GetInstanceProfileInput{
-			InstanceProfileName: aws.String(name),
-		})
-		if err != nil {
-			return createdRole, createdProfile, errors.Wrap(err, "instance-profile propogation waiter timed out")
-		}
 		time.Sleep(DefaultInstanceProfilePropagationDelay)
 	} else {
 		createdProfile = instanceProfile

--- a/controllers/provisioners/eks/create.go
+++ b/controllers/provisioners/eks/create.go
@@ -31,6 +31,7 @@ func (ctx *EksInstanceGroupContext) Create() error {
 	var (
 		instanceGroup = ctx.GetInstanceGroup()
 		state         = ctx.GetDiscoveredState()
+		lcName        = state.GetActiveLaunchConfigurationName()
 	)
 
 	instanceGroup.SetState(v1alpha1.ReconcileModifying)
@@ -43,7 +44,7 @@ func (ctx *EksInstanceGroupContext) Create() error {
 
 	// create launchconfig
 	if !state.HasLaunchConfiguration() {
-		lcName := fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())
+		lcName = fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())
 		err := ctx.CreateLaunchConfiguration(lcName)
 		if err != nil {
 			return errors.Wrap(err, "failed to create launch configuration")
@@ -51,7 +52,7 @@ func (ctx *EksInstanceGroupContext) Create() error {
 	}
 
 	// create scaling group
-	err = ctx.CreateScalingGroup()
+	err = ctx.CreateScalingGroup(lcName)
 	if err != nil {
 		return errors.Wrap(err, "failed to create scaling group")
 	}
@@ -60,7 +61,7 @@ func (ctx *EksInstanceGroupContext) Create() error {
 	return nil
 }
 
-func (ctx *EksInstanceGroupContext) CreateScalingGroup() error {
+func (ctx *EksInstanceGroupContext) CreateScalingGroup(lcName string) error {
 	var (
 		instanceGroup = ctx.GetInstanceGroup()
 		spec          = instanceGroup.GetEKSSpec()
@@ -77,7 +78,7 @@ func (ctx *EksInstanceGroupContext) CreateScalingGroup() error {
 	err := ctx.AwsWorker.CreateScalingGroup(&autoscaling.CreateAutoScalingGroupInput{
 		AutoScalingGroupName:    aws.String(asgName),
 		DesiredCapacity:         aws.Int64(spec.GetMinSize()),
-		LaunchConfigurationName: aws.String(state.GetActiveLaunchConfigurationName()),
+		LaunchConfigurationName: aws.String(lcName),
 		MinSize:                 aws.Int64(spec.GetMinSize()),
 		MaxSize:                 aws.Int64(spec.GetMaxSize()),
 		VPCZoneIdentifier:       aws.String(common.ConcatenateList(configuration.GetSubnets(), ",")),
@@ -87,16 +88,6 @@ func (ctx *EksInstanceGroupContext) CreateScalingGroup() error {
 		return err
 	}
 	ctx.Log.Info("created scaling group", "instancegroup", instanceGroup.GetName(), "scalinggroup", asgName)
-	scalingGroup, err := ctx.AwsWorker.GetAutoscalingGroup(asgName)
-	if err != nil {
-		return err
-	}
-
-	if scalingGroup == nil {
-		return nil
-	}
-
-	state.SetScalingGroup(scalingGroup)
 
 	if err := ctx.UpdateMetricsCollection(asgName); err != nil {
 		return err
@@ -124,17 +115,8 @@ func (ctx *EksInstanceGroupContext) CreateLaunchConfiguration(name string) error
 	}
 
 	ctx.Log.Info("created launchconfig", "instancegroup", instanceGroup.GetName(), "launchconfig", name)
-	lc, err := ctx.AwsWorker.GetAutoscalingLaunchConfig(name)
-	if err != nil {
-		return err
-	}
-
-	if lc != nil {
-		status.SetActiveLaunchConfigurationName(name)
-		state.SetActiveLaunchConfigurationName(name)
-		state.SetLaunchConfiguration(lc)
-	}
-
+	status.SetActiveLaunchConfigurationName(name)
+	state.SetActiveLaunchConfigurationName(name)
 	return nil
 }
 

--- a/controllers/provisioners/eks/create_test.go
+++ b/controllers/provisioners/eks/create_test.go
@@ -140,7 +140,6 @@ func TestCreateScalingGroupPositive(t *testing.T) {
 
 	err := ctx.Create()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(ctx.GetDiscoveredState().GetScalingGroup()).To(gomega.Equal(mockScalingGroup))
 	g.Expect(ctx.GetState()).To(gomega.Equal(v1alpha1.ReconcileModified))
 }
 
@@ -254,23 +253,11 @@ func TestCreateLaunchConfigNegative(t *testing.T) {
 		},
 	})
 
-	asgMock.DescribeLaunchConfigurationsErr = errors.New("some-error")
+	asgMock.CreateLaunchConfigurationErr = errors.New("some-error")
 	err := ctx.Create()
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(ctx.GetState()).To(gomega.Equal(v1alpha1.ReconcileModifying))
-	asgMock.DescribeLaunchConfigurationsErr = nil
-
-	asgMock.CreateLaunchConfigurationErr = errors.New("some-error")
-	err = ctx.Create()
-	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(ctx.GetState()).To(gomega.Equal(v1alpha1.ReconcileModifying))
 	asgMock.CreateLaunchConfigurationErr = nil
-
-	asgMock.DescribeAutoScalingGroupsErr = errors.New("some-error")
-	err = ctx.Create()
-	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(ctx.GetState()).To(gomega.Equal(v1alpha1.ReconcileModifying))
-	asgMock.DescribeAutoScalingGroupsErr = nil
 
 	asgMock.CreateAutoScalingGroupErr = errors.New("some-error")
 	err = ctx.Create()


### PR DESCRIPTION
Ref #112 

This optimizes the Create flow to reduce number of API calls being made.
Calls removed from create flow:
- `WaitUntilInstanceProfileExists`
- `DescribeLaunchConfigurations`
- `DescribeAutoScalingGroups`

- [x] BDD Passing