### PR TITLE
AWS API Optimization - IAM

### DIFF
--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -50,7 +50,7 @@ type AwsWorker struct {
 }
 
 var (
-	DefaultInstanceProfilePropagationDelay = time.Second * 20
+	DefaultInstanceProfilePropagationDelay = time.Second * 25
 	DefaultWaiterDuration                  = time.Second * 5
 	DefaultWaiterRetries                   = 12
 
@@ -286,7 +286,7 @@ func (w *AwsWorker) DeleteScalingGroupRole(name string, managedPolicies []string
 	return nil
 }
 
-func (w *AwsWorker) CreateUpdateScalingGroupRole(name string, managedPolicies []string) (*iam.Role, *iam.InstanceProfile, error) {
+func (w *AwsWorker) CreateScalingGroupRole(name string, managedPolicies []string) (*iam.Role, *iam.InstanceProfile, error) {
 	var (
 		assumeRolePolicyDocument = `{
 			"Version": "2012-10-17",
@@ -310,6 +310,15 @@ func (w *AwsWorker) CreateUpdateScalingGroupRole(name string, managedPolicies []
 			return createdRole, createdProfile, errors.Wrap(err, "failed to create role")
 		}
 		createdRole = out.Role
+		for _, policy := range managedPolicies {
+			_, err = w.IamClient.AttachRolePolicy(&iam.AttachRolePolicyInput{
+				RoleName:  aws.String(name),
+				PolicyArn: aws.String(policy),
+			})
+			if err != nil {
+				return createdRole, createdProfile, errors.Wrap(err, "failed to attach role policies")
+			}
+		}
 	} else {
 		createdRole = role
 	}
@@ -323,30 +332,21 @@ func (w *AwsWorker) CreateUpdateScalingGroupRole(name string, managedPolicies []
 		}
 		createdProfile = out.InstanceProfile
 		time.Sleep(DefaultInstanceProfilePropagationDelay)
-	} else {
-		createdProfile = instanceProfile
-	}
 
-	_, err := w.IamClient.AddRoleToInstanceProfile(&iam.AddRoleToInstanceProfileInput{
-		InstanceProfileName: aws.String(name),
-		RoleName:            aws.String(name),
-	})
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() != iam.ErrCodeLimitExceededException {
-				return createdRole, createdProfile, errors.Wrap(err, "failed to attach instance-profile")
-			}
-		}
-	}
-
-	for _, policy := range managedPolicies {
-		_, err = w.IamClient.AttachRolePolicy(&iam.AttachRolePolicyInput{
-			RoleName:  aws.String(name),
-			PolicyArn: aws.String(policy),
+		_, err = w.IamClient.AddRoleToInstanceProfile(&iam.AddRoleToInstanceProfileInput{
+			InstanceProfileName: aws.String(name),
+			RoleName:            aws.String(name),
 		})
 		if err != nil {
-			return createdRole, createdProfile, errors.Wrap(err, "failed to attach policies")
+			if aerr, ok := err.(awserr.Error); ok {
+				if aerr.Code() != iam.ErrCodeLimitExceededException {
+					return createdRole, createdProfile, errors.Wrap(err, "failed to attach instance-profile")
+				}
+			}
 		}
+
+	} else {
+		createdProfile = instanceProfile
 	}
 
 	return createdRole, createdProfile, nil

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -299,6 +299,19 @@ func (w *AwsWorker) AttachManagedPolicies(name string, managedPolicies []string)
 	return nil
 }
 
+func (w *AwsWorker) DetachManagedPolicies(name string, managedPolicies []string) error {
+	for _, policy := range managedPolicies {
+		_, err := w.IamClient.DetachRolePolicy(&iam.DetachRolePolicyInput{
+			RoleName:  aws.String(name),
+			PolicyArn: aws.String(policy),
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to detach role policies")
+		}
+	}
+	return nil
+}
+
 func (w *AwsWorker) ListRolePolicies(name string) ([]*iam.AttachedPolicy, error) {
 	policies := []*iam.AttachedPolicy{}
 	err := w.IamClient.ListAttachedRolePoliciesPages(

--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -40,6 +40,7 @@ type DiscoveredState struct {
 	LaunchConfiguration           *autoscaling.LaunchConfiguration
 	ActiveLaunchConfigurationName string
 	IAMRole                       *iam.Role
+	AttachedPolicies              []*iam.AttachedPolicy
 	InstanceProfile               *iam.InstanceProfile
 	Publisher                     kubeprovider.EventPublisher
 }
@@ -80,6 +81,14 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 	if val, ok := ctx.AwsWorker.RoleExist(roleName); ok {
 		state.SetRole(val)
 		status.SetNodesArn(aws.StringValue(val.Arn))
+
+		if !configuration.HasExistingRole() {
+			policies, err := ctx.AwsWorker.ListRolePolicies(roleName)
+			if err != nil {
+				return errors.Wrap(err, "failed to list attached role policies")
+			}
+			state.SetAttachedPolicies(policies)
+		}
 	}
 
 	if val, ok := ctx.AwsWorker.InstanceProfileExist(instanceProfileName); ok {
@@ -183,6 +192,15 @@ func (d *DiscoveredState) SetOwnedScalingGroups(groups []*autoscaling.Group) {
 }
 func (d *DiscoveredState) GetOwnedScalingGroups() []*autoscaling.Group {
 	return d.OwnedScalingGroups
+}
+func (d *DiscoveredState) SetAttachedPolicies(policies []*iam.AttachedPolicy) {
+	d.AttachedPolicies = policies
+}
+func (d *DiscoveredState) GetAttachedPolicies() []*iam.AttachedPolicy {
+	if d.AttachedPolicies == nil {
+		d.AttachedPolicies = []*iam.AttachedPolicy{}
+	}
+	return d.AttachedPolicies
 }
 func (d *DiscoveredState) SetLaunchConfiguration(lc *autoscaling.LaunchConfiguration) {
 	if lc != nil {

--- a/controllers/provisioners/eks/create.go
+++ b/controllers/provisioners/eks/create.go
@@ -130,17 +130,18 @@ func (ctx *EksInstanceGroupContext) CreateManagedRole() error {
 	)
 
 	if configuration.HasExistingRole() {
+		// avoid updating if using an existing role
 		return nil
 	}
 
 	// create a controller-owned role for the instancegroup
 	managedPolicies := ctx.GetManagedPoliciesList(additionalPolicies)
 
-	role, profile, err := ctx.AwsWorker.CreateUpdateScalingGroupRole(roleName, managedPolicies)
+	role, profile, err := ctx.AwsWorker.CreateScalingGroupRole(roleName, managedPolicies)
 	if err != nil {
 		return err
 	}
-	ctx.Log.Info("created managed role", "instancegroup", instanceGroup.GetName(), "iamrole", roleName)
+	ctx.Log.Info("reconciled managed role", "instancegroup", instanceGroup.GetName(), "iamrole", roleName)
 
 	state.SetRole(role)
 	state.SetInstanceProfile(profile)

--- a/controllers/provisioners/eks/eks_test.go
+++ b/controllers/provisioners/eks/eks_test.go
@@ -154,6 +154,19 @@ func MockCustomResourceDefinition() *unstructured.Unstructured {
 	}
 }
 
+func MockAttachedPolicies(policies ...string) []*iam.AttachedPolicy {
+	mock := []*iam.AttachedPolicy{}
+	for _, p := range policies {
+		arn := fmt.Sprintf("%v/%v", awsprovider.IAMPolicyPrefix, p)
+		policy := &iam.AttachedPolicy{
+			PolicyName: aws.String(p),
+			PolicyArn:  aws.String(arn),
+		}
+		mock = append(mock, policy)
+	}
+	return mock
+}
+
 func MockTagDescription(key, value string) *autoscaling.TagDescription {
 	return &autoscaling.TagDescription{
 		Key:   aws.String(key),
@@ -359,7 +372,9 @@ type MockIamClient struct {
 	AddRoleToInstanceProfileErr       error
 	RemoveRoleFromInstanceProfileErr  error
 	AttachRolePolicyErr               error
+	AttachRolePolicyCallCount         int
 	DetachRolePolicyErr               error
+	DetachRolePolicyCallCount         int
 	WaitUntilInstanceProfileExistsErr error
 	ListAttachedRolePoliciesErr       error
 	Role                              *iam.Role
@@ -418,10 +433,12 @@ func (i *MockIamClient) RemoveRoleFromInstanceProfile(input *iam.RemoveRoleFromI
 }
 
 func (i *MockIamClient) AttachRolePolicy(input *iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error) {
+	i.AttachRolePolicyCallCount++
 	return &iam.AttachRolePolicyOutput{}, i.AttachRolePolicyErr
 }
 
 func (i *MockIamClient) DetachRolePolicy(input *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error) {
+	i.DetachRolePolicyCallCount++
 	return &iam.DetachRolePolicyOutput{}, i.DetachRolePolicyErr
 }
 

--- a/controllers/provisioners/eks/eks_test.go
+++ b/controllers/provisioners/eks/eks_test.go
@@ -361,8 +361,26 @@ type MockIamClient struct {
 	AttachRolePolicyErr               error
 	DetachRolePolicyErr               error
 	WaitUntilInstanceProfileExistsErr error
+	ListAttachedRolePoliciesErr       error
 	Role                              *iam.Role
 	InstanceProfile                   *iam.InstanceProfile
+	AttachedPolicies                  []*iam.AttachedPolicy
+}
+
+func (i *MockIamClient) ListAttachedRolePolicies(input *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
+	if i.AttachedPolicies != nil {
+		return &iam.ListAttachedRolePoliciesOutput{AttachedPolicies: i.AttachedPolicies}, i.ListAttachedRolePoliciesErr
+	}
+	return &iam.ListAttachedRolePoliciesOutput{}, i.ListAttachedRolePoliciesErr
+}
+
+func (i *MockIamClient) ListAttachedRolePoliciesPages(input *iam.ListAttachedRolePoliciesInput, callback func(*iam.ListAttachedRolePoliciesOutput, bool) bool) error {
+	page, err := i.ListAttachedRolePolicies(input)
+	if err != nil {
+		return err
+	}
+	callback(page, false)
+	return nil
 }
 
 func (i *MockIamClient) CreateRole(input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -310,6 +310,7 @@ func (ctx *EksInstanceGroupContext) UpdateNodeReadyCondition() bool {
 		if !state.IsNodesReady() {
 			state.Publisher.Publish(kubeprovider.NodesReadyEvent, "instancegroup", instanceGroup.GetName(), "instances", instances)
 		}
+		ctx.Log.Info("desired nodes are ready", "instancegroup", instanceGroup.GetName(), "instances", strings.Join(instanceIds, ","))
 		state.SetNodesReady(true)
 		conditions = append(conditions, v1alpha1.NewInstanceGroupCondition(v1alpha1.NodesReady, corev1.ConditionTrue))
 		status.SetConditions(conditions)
@@ -319,6 +320,7 @@ func (ctx *EksInstanceGroupContext) UpdateNodeReadyCondition() bool {
 	if state.IsNodesReady() {
 		state.Publisher.Publish(kubeprovider.NodesNotReadyEvent, "instancegroup", instanceGroup.GetName(), "instances", instances)
 	}
+	ctx.Log.Info("desired nodes are not ready", "instancegroup", instanceGroup.GetName(), "instances", strings.Join(instanceIds, ","))
 	state.SetNodesReady(false)
 	conditions = append(conditions, v1alpha1.NewInstanceGroupCondition(v1alpha1.NodesReady, corev1.ConditionFalse))
 	status.SetConditions(conditions)

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -310,7 +310,7 @@ func (ctx *EksInstanceGroupContext) UpdateNodeReadyCondition() bool {
 		if !state.IsNodesReady() {
 			state.Publisher.Publish(kubeprovider.NodesReadyEvent, "instancegroup", instanceGroup.GetName(), "instances", instances)
 		}
-		ctx.Log.Info("desired nodes are ready", "instancegroup", instanceGroup.GetName(), "instances", strings.Join(instanceIds, ","))
+		ctx.Log.Info("desired nodes are ready", "instancegroup", instanceGroup.GetName(), "instances", instances)
 		state.SetNodesReady(true)
 		conditions = append(conditions, v1alpha1.NewInstanceGroupCondition(v1alpha1.NodesReady, corev1.ConditionTrue))
 		status.SetConditions(conditions)
@@ -320,7 +320,7 @@ func (ctx *EksInstanceGroupContext) UpdateNodeReadyCondition() bool {
 	if state.IsNodesReady() {
 		state.Publisher.Publish(kubeprovider.NodesNotReadyEvent, "instancegroup", instanceGroup.GetName(), "instances", instances)
 	}
-	ctx.Log.Info("desired nodes are not ready", "instancegroup", instanceGroup.GetName(), "instances", strings.Join(instanceIds, ","))
+	ctx.Log.Info("desired nodes are not ready", "instancegroup", instanceGroup.GetName(), "instances", instances)
 	state.SetNodesReady(false)
 	conditions = append(conditions, v1alpha1.NewInstanceGroupCondition(v1alpha1.NodesReady, corev1.ConditionFalse))
 	status.SetConditions(conditions)

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -334,8 +334,8 @@ func (ctx *EksInstanceGroupContext) UpdateManagedPolicies(roleName string) error
 	attachedPolicies := state.GetAttachedPolicies()
 
 	for _, policy := range attachedPolicies {
-		name := aws.StringValue(policy.PolicyName)
-		if !common.ContainsString(managedPolicies, name) {
+		arn := aws.StringValue(policy.PolicyArn)
+		if !common.ContainsString(managedPolicies, arn) {
 			needsUpdate = true
 		}
 	}

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -329,7 +329,6 @@ func (ctx *EksInstanceGroupContext) UpdateManagedPolicies(roleName string) error
 		needsUpdate        bool
 	)
 
-	// create a controller-owned role for the instancegroup
 	managedPolicies := ctx.GetManagedPoliciesList(additionalPolicies)
 	attachedPolicies := state.GetAttachedPolicies()
 


### PR DESCRIPTION
Fixes #112 

This optimizes the IAM calls we make by only trying to attach managed policies if they are not attached.

- [x] BDD test