### PR TITLE
AWS SDK Caching

### DIFF
--- a/controllers/common/bootstrap.go
+++ b/controllers/common/bootstrap.go
@@ -16,6 +16,8 @@ limitations under the License.
 package common
 
 import (
+	"time"
+
 	awsauth "github.com/keikoproj/aws-auth/pkg/mapper"
 	"k8s.io/client-go/kubernetes"
 )
@@ -29,6 +31,10 @@ func GetNodeBootstrapUpsert(arn string) *awsauth.UpsertArguments {
 			"system:bootstrappers",
 			"system:nodes",
 		},
+		WithRetries:   true,
+		MinRetryTime:  time.Millisecond * 100,
+		MaxRetryTime:  time.Second * 30,
+		MaxRetryCount: 12,
 	}
 }
 
@@ -41,6 +47,10 @@ func GetNodeBootstrapRemove(arn string) *awsauth.RemoveArguments {
 			"system:bootstrappers",
 			"system:nodes",
 		},
+		WithRetries:   true,
+		MinRetryTime:  time.Millisecond * 100,
+		MaxRetryTime:  time.Second * 30,
+		MaxRetryCount: 12,
 	}
 }
 

--- a/controllers/common/bootstrap.go
+++ b/controllers/common/bootstrap.go
@@ -22,8 +22,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func GetNodeBootstrapUpsert(arn string) *awsauth.UpsertArguments {
-	return &awsauth.UpsertArguments{
+func GetNodeBootstrapUpsert(arn string) *awsauth.MapperArguments {
+	return &awsauth.MapperArguments{
 		MapRoles: true,
 		RoleARN:  arn,
 		Username: "system:node:{{EC2PrivateDNSName}}",
@@ -38,8 +38,8 @@ func GetNodeBootstrapUpsert(arn string) *awsauth.UpsertArguments {
 	}
 }
 
-func GetNodeBootstrapRemove(arn string) *awsauth.RemoveArguments {
-	return &awsauth.RemoveArguments{
+func GetNodeBootstrapRemove(arn string) *awsauth.MapperArguments {
+	return &awsauth.MapperArguments{
 		MapRoles: true,
 		RoleARN:  arn,
 		Username: "system:node:{{EC2PrivateDNSName}}",

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -47,6 +47,7 @@ const (
 	CacheDefaultTTL                 time.Duration = time.Second * 0
 	DescribeAutoScalingGroupsTTL    time.Duration = 60 * time.Second
 	DescribeLaunchConfigurationsTTL time.Duration = 60 * time.Second
+	ListAttachedRolePoliciesTTL     time.Duration = 60 * time.Second
 	GetRoleTTL                      time.Duration = 60 * time.Second
 	GetInstanceProfileTTL           time.Duration = 60 * time.Second
 	DescribeNodegroupTTL            time.Duration = 60 * time.Second
@@ -699,6 +700,7 @@ func GetAwsIamClient(region string, cacheCfg *cache.Config) iamiface.IAMAPI {
 	cache.AddCaching(sess, cacheCfg)
 	cacheCfg.SetCacheTTL("iam", "GetInstanceProfile", GetInstanceProfileTTL)
 	cacheCfg.SetCacheTTL("iam", "GetRole", GetRoleTTL)
+	cacheCfg.SetCacheTTL("iam", "ListAttachedRolePolicies", ListAttachedRolePoliciesTTL)
 	sess.Handlers.Complete.PushFront(func(r *request.Request) {
 		ctx := r.HTTPRequest.Context()
 		log.V(1).Info("AWS API call",

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/keikoproj/aws-sdk-go-cache/cache"
 	"github.com/keikoproj/instance-manager/controllers/common"
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -40,6 +41,18 @@ import (
 
 var (
 	log = ctrl.Log.WithName("aws-provider")
+)
+
+const (
+	CacheDefaultTTL                 time.Duration = time.Second * 0
+	DescribeAutoScalingGroupsTTL    time.Duration = 60 * time.Second
+	DescribeLaunchConfigurationsTTL time.Duration = 60 * time.Second
+	GetRoleTTL                      time.Duration = 60 * time.Second
+	GetInstanceProfileTTL           time.Duration = 60 * time.Second
+	DescribeNodegroupTTL            time.Duration = 60 * time.Second
+	DescribeClusterTTL              time.Duration = 180 * time.Second
+	CacheMaxItems                   int64         = 5000
+	CacheItemsToPrune               uint32        = 500
 )
 
 type AwsWorker struct {
@@ -596,35 +609,69 @@ func GetRegion() (string, error) {
 }
 
 // GetAwsAsgClient returns an ASG client
-func GetAwsAsgClient(region string) autoscalingiface.AutoScalingAPI {
+func GetAwsAsgClient(region string, cacheCfg *cache.Config) autoscalingiface.AutoScalingAPI {
 	config := aws.NewConfig().WithRegion(region).WithCredentialsChainVerboseErrors(true)
 	config = request.WithRetryer(config, NewRetryLogger(DefaultRetryer))
 	sess, err := session.NewSession(config)
 	if err != nil {
 		panic(err)
 	}
+
+	cache.AddCaching(sess, cacheCfg)
+	cacheCfg.SetCacheTTL("autoscaling", "DescribeAutoScalingGroups", DescribeAutoScalingGroupsTTL)
+	cacheCfg.SetCacheTTL("autoscaling", "DescribeLaunchConfigurations", DescribeLaunchConfigurationsTTL)
+	sess.Handlers.Complete.PushFront(func(r *request.Request) {
+		ctx := r.HTTPRequest.Context()
+		log.V(1).Info("AWS API call",
+			"hit", cache.IsCacheHit(ctx),
+			"service", r.ClientInfo.ServiceName,
+			"operation", r.Operation.Name,
+		)
+	})
 	return autoscaling.New(sess)
 }
 
 // GetAwsEksClient returns an EKS client
-func GetAwsEksClient(region string) eksiface.EKSAPI {
+func GetAwsEksClient(region string, cacheCfg *cache.Config) eksiface.EKSAPI {
 	config := aws.NewConfig().WithRegion(region).WithCredentialsChainVerboseErrors(true)
 	config = request.WithRetryer(config, NewRetryLogger(DefaultRetryer))
 	sess, err := session.NewSession(config)
 	if err != nil {
 		panic(err)
 	}
+	cache.AddCaching(sess, cacheCfg)
+	cacheCfg.SetCacheTTL("eks", "DescribeCluster", DescribeClusterTTL)
+	cacheCfg.SetCacheTTL("eks", "DescribeNodegroup", DescribeNodegroupTTL)
+	sess.Handlers.Complete.PushFront(func(r *request.Request) {
+		ctx := r.HTTPRequest.Context()
+		log.V(1).Info("AWS API call",
+			"hit", cache.IsCacheHit(ctx),
+			"service", r.ClientInfo.ServiceName,
+			"operation", r.Operation.Name,
+		)
+	})
 	return eks.New(sess, config)
 }
 
 // GetAwsIAMClient returns an IAM client
-func GetAwsIamClient(region string) iamiface.IAMAPI {
+func GetAwsIamClient(region string, cacheCfg *cache.Config) iamiface.IAMAPI {
 	config := aws.NewConfig().WithRegion(region).WithCredentialsChainVerboseErrors(true)
 	config = request.WithRetryer(config, NewRetryLogger(DefaultRetryer))
 	sess, err := session.NewSession(config)
 	if err != nil {
 		panic(err)
 	}
+	cache.AddCaching(sess, cacheCfg)
+	cacheCfg.SetCacheTTL("iam", "GetInstanceProfile", GetInstanceProfileTTL)
+	cacheCfg.SetCacheTTL("iam", "GetRole", GetRoleTTL)
+	sess.Handlers.Complete.PushFront(func(r *request.Request) {
+		ctx := r.HTTPRequest.Context()
+		log.V(1).Info("AWS API call",
+			"hit", cache.IsCacheHit(ctx),
+			"service", r.ClientInfo.ServiceName,
+			"operation", r.Operation.Name,
+		)
+	})
 	return iam.New(sess, config)
 }
 

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -659,7 +659,7 @@ func GetAwsAsgClient(region string, cacheCfg *cache.Config) autoscalingiface.Aut
 	sess.Handlers.Complete.PushFront(func(r *request.Request) {
 		ctx := r.HTTPRequest.Context()
 		log.V(1).Info("AWS API call",
-			"hit", cache.IsCacheHit(ctx),
+			"cacheHit", cache.IsCacheHit(ctx),
 			"service", r.ClientInfo.ServiceName,
 			"operation", r.Operation.Name,
 		)
@@ -681,7 +681,7 @@ func GetAwsEksClient(region string, cacheCfg *cache.Config) eksiface.EKSAPI {
 	sess.Handlers.Complete.PushFront(func(r *request.Request) {
 		ctx := r.HTTPRequest.Context()
 		log.V(1).Info("AWS API call",
-			"hit", cache.IsCacheHit(ctx),
+			"cacheHit", cache.IsCacheHit(ctx),
 			"service", r.ClientInfo.ServiceName,
 			"operation", r.Operation.Name,
 		)
@@ -704,7 +704,7 @@ func GetAwsIamClient(region string, cacheCfg *cache.Config) iamiface.IAMAPI {
 	sess.Handlers.Complete.PushFront(func(r *request.Request) {
 		ctx := r.HTTPRequest.Context()
 		log.V(1).Info("AWS API call",
-			"hit", cache.IsCacheHit(ctx),
+			"cacheHit", cache.IsCacheHit(ctx),
 			"service", r.ClientInfo.ServiceName,
 			"operation", r.Operation.Name,
 		)

--- a/controllers/provisioners/eks/delete.go
+++ b/controllers/provisioners/eks/delete.go
@@ -16,6 +16,7 @@ limitations under the License.
 package eks
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
@@ -89,7 +90,8 @@ func (ctx *EksInstanceGroupContext) DeleteLaunchConfiguration() error {
 
 	for _, lc := range state.GetLaunchConfigurations() {
 		name := aws.StringValue(lc.LaunchConfigurationName)
-		if strings.HasPrefix(name, ctx.ResourcePrefix) {
+		matcher := fmt.Sprintf("%v-", ctx.ResourcePrefix)
+		if strings.HasPrefix(name, matcher) {
 			err := ctx.AwsWorker.DeleteLaunchConfig(name)
 			if err != nil {
 				return err

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -480,7 +480,8 @@ func (ctx *EksInstanceGroupContext) GetTimeSortedLaunchConfigurations() []*autos
 	configurations := []*autoscaling.LaunchConfiguration{}
 	for _, lc := range state.GetLaunchConfigurations() {
 		name := aws.StringValue(lc.LaunchConfigurationName)
-		if strings.HasPrefix(name, ctx.ResourcePrefix) {
+		matcher := fmt.Sprintf("%v-", ctx.ResourcePrefix)
+		if strings.HasPrefix(name, matcher) {
 			configurations = append(configurations, lc)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/protobuf v1.4.1 // indirect
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
-	github.com/keikoproj/aws-auth v0.0.0-20200510193503-dcb7aa6350e1
+	github.com/keikoproj/aws-auth v0.0.0-20200519230504-67c8d09ec1b3
 	github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/onsi/gomega v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.30.24
-	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cucumber/godog v0.8.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
@@ -13,11 +12,10 @@ require (
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/keikoproj/aws-auth v0.0.0-20200510193503-dcb7aa6350e1
+	github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/onsi/gomega v1.9.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/common v0.9.1 // indirect
-	github.com/prometheus/procfs v0.0.8 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/zap v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/protobuf v1.4.1 // indirect
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
-	github.com/keikoproj/aws-auth v0.0.0-20200529195926-d5c07c5ca0f4
+	github.com/keikoproj/aws-auth v0.0.0-20200529211237-b481594963fa
 	github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/onsi/gomega v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/protobuf v1.4.1 // indirect
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
-	github.com/keikoproj/aws-auth v0.0.0-20200519230504-67c8d09ec1b3
+	github.com/keikoproj/aws-auth v0.0.0-20200529195926-d5c07c5ca0f4
 	github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/onsi/gomega v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws/aws-sdk-go v1.25.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.24 h1:y3JPD51VuEmVqN3BEDVm4amGpDma2cKJcDPuAU1OR58=
 github.com/aws/aws-sdk-go v1.30.24/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -183,6 +184,7 @@ github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -196,8 +198,14 @@ github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGn
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
+github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
+github.com/karlseguin/expect v1.0.1 h1:z4wy4npwwHSWKjGWH85WNJO42VQhovxTCZDSzhjo8hY=
+github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
 github.com/keikoproj/aws-auth v0.0.0-20200510193503-dcb7aa6350e1 h1:WKfi7DAtxHHoQNQM+oU1Y4R81HLmiSS7DHZe2o058oM=
 github.com/keikoproj/aws-auth v0.0.0-20200510193503-dcb7aa6350e1/go.mod h1:/DQXDbPWiYraLMdLTbmf4JHjxQJkcW6+he0EwBG+snU=
+github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a h1:T4PGY8X0NbpEPM3U7HxLX616PBgjWxvn2YQNYkdaEeU=
+github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a/go.mod h1:PqUW3kzHKLscAxysVG6mJz5wmk4JV9GSwX+k4qjqi1c=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -311,6 +319,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
+github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -367,6 +377,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f h1:QBjCr1Fz5kw158VqdE9JfI9cJnl/ymnJWAdMuinqL7Y=
@@ -471,6 +482,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/karlseguin/expect.v1 v1.0.1 h1:9u0iUltnhFbJTHaSIH0EP+cuTU5rafIgmcsEsg2JQFw=
+gopkg.in/karlseguin/expect.v1 v1.0.1/go.mod h1:uB7QIJBcclvYbwlUDkSCsGjAOMis3fP280LyhuDEf2I=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/go.sum
+++ b/go.sum
@@ -204,10 +204,8 @@ github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+A
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/karlseguin/expect v1.0.1 h1:z4wy4npwwHSWKjGWH85WNJO42VQhovxTCZDSzhjo8hY=
 github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
-github.com/keikoproj/aws-auth v0.0.0-20200519230504-67c8d09ec1b3 h1:iftFwKRZphQwlJLAP7AnHzgcIdetqbF5kZ0fax5br7A=
-github.com/keikoproj/aws-auth v0.0.0-20200519230504-67c8d09ec1b3/go.mod h1:3uzLNZsb9kA7gsmMavI/Svq59lemTEKAuyrPswTo7RI=
-github.com/keikoproj/aws-auth v0.0.0-20200529195926-d5c07c5ca0f4 h1:YFshr6UkryIr2laEyNJ1FIMdYXQlxDQ/3BSOElltwsA=
-github.com/keikoproj/aws-auth v0.0.0-20200529195926-d5c07c5ca0f4/go.mod h1:3uzLNZsb9kA7gsmMavI/Svq59lemTEKAuyrPswTo7RI=
+github.com/keikoproj/aws-auth v0.0.0-20200529211237-b481594963fa h1:UbB7HFHZ8jbmzbuepliGfD3+bPbH0KGZzvKXTHL/8SQ=
+github.com/keikoproj/aws-auth v0.0.0-20200529211237-b481594963fa/go.mod h1:3uzLNZsb9kA7gsmMavI/Svq59lemTEKAuyrPswTo7RI=
 github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a h1:T4PGY8X0NbpEPM3U7HxLX616PBgjWxvn2YQNYkdaEeU=
 github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a/go.mod h1:PqUW3kzHKLscAxysVG6mJz5wmk4JV9GSwX+k4qjqi1c=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
@@ -202,8 +204,8 @@ github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+A
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/karlseguin/expect v1.0.1 h1:z4wy4npwwHSWKjGWH85WNJO42VQhovxTCZDSzhjo8hY=
 github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
-github.com/keikoproj/aws-auth v0.0.0-20200510193503-dcb7aa6350e1 h1:WKfi7DAtxHHoQNQM+oU1Y4R81HLmiSS7DHZe2o058oM=
-github.com/keikoproj/aws-auth v0.0.0-20200510193503-dcb7aa6350e1/go.mod h1:/DQXDbPWiYraLMdLTbmf4JHjxQJkcW6+he0EwBG+snU=
+github.com/keikoproj/aws-auth v0.0.0-20200519230504-67c8d09ec1b3 h1:iftFwKRZphQwlJLAP7AnHzgcIdetqbF5kZ0fax5br7A=
+github.com/keikoproj/aws-auth v0.0.0-20200519230504-67c8d09ec1b3/go.mod h1:3uzLNZsb9kA7gsmMavI/Svq59lemTEKAuyrPswTo7RI=
 github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a h1:T4PGY8X0NbpEPM3U7HxLX616PBgjWxvn2YQNYkdaEeU=
 github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a/go.mod h1:PqUW3kzHKLscAxysVG6mJz5wmk4JV9GSwX+k4qjqi1c=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/go.sum
+++ b/go.sum
@@ -206,6 +206,8 @@ github.com/karlseguin/expect v1.0.1 h1:z4wy4npwwHSWKjGWH85WNJO42VQhovxTCZDSzhjo8
 github.com/karlseguin/expect v1.0.1/go.mod h1:zNBxMY8P21owkeogJELCLeHIt+voOSduHYTFUbwRAV8=
 github.com/keikoproj/aws-auth v0.0.0-20200519230504-67c8d09ec1b3 h1:iftFwKRZphQwlJLAP7AnHzgcIdetqbF5kZ0fax5br7A=
 github.com/keikoproj/aws-auth v0.0.0-20200519230504-67c8d09ec1b3/go.mod h1:3uzLNZsb9kA7gsmMavI/Svq59lemTEKAuyrPswTo7RI=
+github.com/keikoproj/aws-auth v0.0.0-20200529195926-d5c07c5ca0f4 h1:YFshr6UkryIr2laEyNJ1FIMdYXQlxDQ/3BSOElltwsA=
+github.com/keikoproj/aws-auth v0.0.0-20200529195926-d5c07c5ca0f4/go.mod h1:3uzLNZsb9kA7gsmMavI/Svq59lemTEKAuyrPswTo7RI=
 github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a h1:T4PGY8X0NbpEPM3U7HxLX616PBgjWxvn2YQNYkdaEeU=
 github.com/keikoproj/aws-sdk-go-cache v0.0.0-20200124200058-ab3c8c94044a/go.mod h1:PqUW3kzHKLscAxysVG6mJz5wmk4JV9GSwX+k4qjqi1c=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	runt "runtime"
 
+	"github.com/keikoproj/aws-sdk-go-cache/cache"
 	instancemgrv1alpha1 "github.com/keikoproj/instance-manager/api/v1alpha1"
 	"github.com/keikoproj/instance-manager/controllers"
 	"github.com/keikoproj/instance-manager/controllers/providers/aws"
@@ -103,10 +104,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	cacheCfg := cache.NewConfig(aws.CacheDefaultTTL, aws.CacheMaxItems, aws.CacheItemsToPrune)
+
 	awsWorker := aws.AwsWorker{
-		IamClient: aws.GetAwsIamClient(awsRegion),
-		AsgClient: aws.GetAwsAsgClient(awsRegion),
-		EksClient: aws.GetAwsEksClient(awsRegion),
+		IamClient: aws.GetAwsIamClient(awsRegion, cacheCfg),
+		AsgClient: aws.GetAwsAsgClient(awsRegion, cacheCfg),
+		EksClient: aws.GetAwsEksClient(awsRegion, cacheCfg),
 	}
 
 	kube := kubeprovider.KubernetesClientSet{


### PR DESCRIPTION
Fixes #87 

This adds caching for AWS calls

- [x] BDD test
- Total calls: 1432
- Cache Hits: 1137
- Cache Misses: 295 (~20%)
- Throttled: 0

- [x] Scale test (20 EKS IGs CREATE/DELETE)
- Total calls: 1953
- Cache Hits: 1071
- Cache Misses: 882 (45%)
- Throttled: 0
