### PR TITLE
Configurable Retries

### DIFF
--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -18,6 +18,10 @@ package aws
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
@@ -32,10 +36,7 @@ import (
 	"github.com/keikoproj/aws-sdk-go-cache/cache"
 	"github.com/keikoproj/instance-manager/controllers/common"
 	"github.com/pkg/errors"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"strings"
-	"time"
 )
 
 var (
@@ -678,9 +679,9 @@ func GetRegion() (string, error) {
 }
 
 // GetAwsAsgClient returns an ASG client
-func GetAwsAsgClient(region string, cacheCfg *cache.Config) autoscalingiface.AutoScalingAPI {
+func GetAwsAsgClient(region string, cacheCfg *cache.Config, maxRetries int) autoscalingiface.AutoScalingAPI {
 	config := aws.NewConfig().WithRegion(region).WithCredentialsChainVerboseErrors(true)
-	config = request.WithRetryer(config, NewRetryLogger(DefaultRetryer))
+	config = request.WithRetryer(config, NewRetryLogger(maxRetries))
 	sess, err := session.NewSession(config)
 	if err != nil {
 		panic(err)
@@ -701,9 +702,9 @@ func GetAwsAsgClient(region string, cacheCfg *cache.Config) autoscalingiface.Aut
 }
 
 // GetAwsEksClient returns an EKS client
-func GetAwsEksClient(region string, cacheCfg *cache.Config) eksiface.EKSAPI {
+func GetAwsEksClient(region string, cacheCfg *cache.Config, maxRetries int) eksiface.EKSAPI {
 	config := aws.NewConfig().WithRegion(region).WithCredentialsChainVerboseErrors(true)
-	config = request.WithRetryer(config, NewRetryLogger(DefaultRetryer))
+	config = request.WithRetryer(config, NewRetryLogger(maxRetries))
 	sess, err := session.NewSession(config)
 	if err != nil {
 		panic(err)
@@ -747,9 +748,9 @@ var UnrecoverableError = CloudResourceReconcileState{UnrecoverableError: true}
 var UnrecoverableDeleteError = CloudResourceReconcileState{UnrecoverableDeleteError: true}
 
 // GetAwsIAMClient returns an IAM client
-func GetAwsIamClient(region string, cacheCfg *cache.Config) iamiface.IAMAPI {
+func GetAwsIamClient(region string, cacheCfg *cache.Config, maxRetries int) iamiface.IAMAPI {
 	config := aws.NewConfig().WithRegion(region).WithCredentialsChainVerboseErrors(true)
-	config = request.WithRetryer(config, NewRetryLogger(DefaultRetryer))
+	config = request.WithRetryer(config, NewRetryLogger(maxRetries))
 	sess, err := session.NewSession(config)
 	if err != nil {
 		panic(err)

--- a/controllers/providers/aws/retry.go
+++ b/controllers/providers/aws/retry.go
@@ -13,16 +13,17 @@ type RetryLogger struct {
 }
 
 var _ request.Retryer = &RetryLogger{}
-
 var DefaultRetryer = client.DefaultRetryer{
-	NumMaxRetries:    50,
+	NumMaxRetries:    12,
 	MinThrottleDelay: time.Second * 5,
 	MaxThrottleDelay: time.Second * 60,
 	MinRetryDelay:    time.Second * 1,
 	MaxRetryDelay:    time.Second * 5,
 }
 
-func NewRetryLogger(retryer client.DefaultRetryer) *RetryLogger {
+func NewRetryLogger(maxRetries int) *RetryLogger {
+	retryer := DefaultRetryer
+	retryer.NumMaxRetries = maxRetries
 	return &RetryLogger{
 		retryer,
 	}

--- a/main.go
+++ b/main.go
@@ -65,10 +65,12 @@ func main() {
 		nodeRelabel            bool
 		controllerConfPath     string
 		maxParallel            int
+		maxAPIRetries          int
 		err                    error
 	)
 
 	flag.IntVar(&maxParallel, "max-workers", 5, "The number of maximum parallel reconciles")
+	flag.IntVar(&maxAPIRetries, "max-api-retries", 12, "The number of maximum retries for failed AWS API calls")
 	flag.Float64Var(&spotRecommendationTime, "spot-recommendation-time", 10.0, "The maximum age of spot recommendation events to consider in minutes")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&controllerConfPath, "controller-config", "/etc/config/controller.conf", "The controller config file")
@@ -109,9 +111,9 @@ func main() {
 	cacheCfg := cache.NewConfig(aws.CacheDefaultTTL, aws.CacheMaxItems, aws.CacheItemsToPrune)
 
 	awsWorker := aws.AwsWorker{
-		IamClient: aws.GetAwsIamClient(awsRegion, cacheCfg),
-		AsgClient: aws.GetAwsAsgClient(awsRegion, cacheCfg),
-		EksClient: aws.GetAwsEksClient(awsRegion, cacheCfg),
+		IamClient: aws.GetAwsIamClient(awsRegion, cacheCfg, maxAPIRetries),
+		AsgClient: aws.GetAwsAsgClient(awsRegion, cacheCfg, maxAPIRetries),
+		EksClient: aws.GetAwsEksClient(awsRegion, cacheCfg, maxAPIRetries),
 	}
 
 	kube := kubeprovider.KubernetesClientSet{


### PR DESCRIPTION
Fixes #118 
This lowers the default retry count to a more reasonable number (50 > 12), and also makes it configurable.