### PR TITLE
uniform finalizer

### DIFF
--- a/controllers/common/utils.go
+++ b/controllers/common/utils.go
@@ -105,17 +105,6 @@ func GetLastElementBy(s, sep string) string {
 	return sp[len(sp)-1]
 }
 
-// RemoveString removes a string 's' from slice 'slice'
-func RemoveString(slice []string, s string) (result []string) {
-	for _, item := range slice {
-		if item == s {
-			continue
-		}
-		result = append(result, item)
-	}
-	return
-}
-
 // ConcatenateList joins lists to strings delimited with `delimiter`
 func ConcatenateList(list []string, delimiter string) string {
 	return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(list)), delimiter), "[]")


### PR DESCRIPTION
Fixes #151 

This modifies the way we set/remove finalizers in order to move to a uniform finalizer for all provisioners without breaking compatibility

- SetFinalizer will add the new finalizer "finalizer.instancegroups.keikoproj.io" (which does not mention provisioner)
- Finalize will remove ALL finalizers - given this is an owned resource that should be OK.

- [x] Basic tests