### PR TITLE
doc & logging fixes

### DIFF
--- a/controllers/providers/kubernetes/rollingupdate.go
+++ b/controllers/providers/kubernetes/rollingupdate.go
@@ -81,7 +81,7 @@ func ProcessRollingUpgradeStrategy(req *RollingUpdateRequest) (bool, error) {
 	log.Info("terminating targets", "scalinggroup", req.ScalingGroupName, "targets", terminateTargets)
 	if err := req.AwsWorker.TerminateScalingInstances(terminateTargets); err != nil {
 		// terminate failures are retryable
-		log.Info("failed to terminate targets", "reason", err.Error, "scalinggroup", req.ScalingGroupName, "targets", terminateTargets)
+		log.Info("failed to terminate targets", "reason", err.Error(), "scalinggroup", req.ScalingGroupName, "targets", terminateTargets)
 		return false, nil
 	}
 	return false, nil

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,29 +51,33 @@ The below are the minimum required policies needed to run the basic operations o
 iam:GetRole
 iam:GetInstanceProfile
 iam:PassRole
-autoscaling:DescribeLaunchConfigurations
-autoscaling:CreateLaunchConfigurations
-autoscaling:DeleteLaunchConfigurations
 autoscaling:DescribeAutoScalingGroups
-autoscaling:CreateAutoScalingGroups
-autoscaling:DeleteAutoScalingGroups
-eks:DescribeNodegroup
+autoscaling:UpdateAutoScalingGroup
+autoscaling:TerminateInstanceInAutoScalingGroup
+autoscaling:CreateLaunchConfiguration
+autoscaling:DeleteLaunchConfiguration
+autoscaling:DeleteAutoScalingGroup
+autoscaling:CreateAutoScalingGroup
 eks:CreateNodegroup
+eks:DescribeNodegroup
 eks:DeleteNodegroup
 eks:UpdateNodegroupConfig
+eks:DescribeCluster
 ```
 
 The following are also required if you want the controller to be creating IAM roles for your instance groups, otherwise you can omit this and provide an existing role in the custom resource.
 
 ```text
-iam:CreateRole
-iam:DeleteRole
 iam:CreateInstanceProfile
-iam:DeleteInstanceProfile
-iam:AttachRolePolicy
-iam:DetachRolePolicy
 iam:RemoveRoleFromInstanceProfile
+iam:CreateRole
+iam:AttachRolePolicy
 iam:AddRoleToInstanceProfile
+iam:DetachRolePolicy
+iam:ListAttachedRolePolicies
+iam:DeleteInstanceProfile
+iam:DeleteRole
+autoscaling:DescribeLaunchConfigurations
 ```
 
 You can choose to create the initial instance-manager IAM role with these additional policies attached directly, or create a new role and use other solutions such as KIAM to assume it. You can refer to the documentation provided by KIAM [here](https://github.com/uswitch/kiam#overview).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,5 @@
 # Documentation
 
-- [Installation](install)
-- [FAQ](faq)
-- [EKS Provisioner API Reference](eks)
-
-<!-- Markdown link -->
-[install]: https://github.com/keikoproj/instance-manager/blob/master/docs/INSTALL.md
-[faq]: https://github.com/keikoproj/instance-manager/blob/master/docs/FAQ.md
-[eks]: https://github.com/keikoproj/instance-manager/blob/master/docs/EKS.md
+- [Installation](https://github.com/keikoproj/instance-manager/blob/master/docs/INSTALL.md)
+- [FAQ](https://github.com/keikoproj/instance-manager/blob/master/docs/FAQ.md)
+- [EKS Provisioner API Reference](https://github.com/keikoproj/instance-manager/blob/master/docs/EKS.md)


### PR DESCRIPTION
Fixes #150 

Logging fixed after adding missing `()`

```
failed to terminate targets	{"reason": "AccessDenied: User: <reducted> is not authorized to perform: autoscaling:TerminateInstanceInAutoScalingGroup on resource:<reducted>\n\tstatus code: 403, request id: 3d1d3fab-e282-42f6-90dc-61699b9397f7", "scalinggroup": "instancemgr-dev-instance-manager-my-instance-group-2", "targets": ["i-025a0d00ddadf24b8"]}
```

Fixed docs for IAM permissions needed