### PR TITLE
Resolve security groups / subnets by Name tag

### DIFF
--- a/api/v1alpha1/instancegroup_types.go
+++ b/api/v1alpha1/instancegroup_types.go
@@ -424,6 +424,12 @@ func (c *EKSConfiguration) GetVolumes() []NodeVolume {
 func (c *EKSConfiguration) GetBootstrapArguments() string {
 	return c.BootstrapArguments
 }
+func (c *EKSConfiguration) GetSecurityGroups() []string {
+	if c.NodeSecurityGroups == nil {
+		return []string{}
+	}
+	return c.NodeSecurityGroups
+}
 func (c *EKSConfiguration) GetTags() []map[string]string {
 	if c.Tags == nil {
 		return []map[string]string{}

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -49,13 +49,14 @@ var (
 const (
 	CacheDefaultTTL                 time.Duration = 0 * time.Second
 	DescribeAutoScalingGroupsTTL    time.Duration = 60 * time.Second
-	DescribeSecurityGroupsTTL       time.Duration = 60 * time.Second
 	DescribeLaunchConfigurationsTTL time.Duration = 60 * time.Second
 	ListAttachedRolePoliciesTTL     time.Duration = 60 * time.Second
 	GetRoleTTL                      time.Duration = 60 * time.Second
 	GetInstanceProfileTTL           time.Duration = 60 * time.Second
 	DescribeNodegroupTTL            time.Duration = 60 * time.Second
 	DescribeClusterTTL              time.Duration = 180 * time.Second
+	DescribeSecurityGroupsTTL       time.Duration = 180 * time.Second
+	DescribeSubnetsTTL              time.Duration = 180 * time.Second
 	CacheMaxItems                   int64         = 5000
 	CacheItemsToPrune               uint32        = 500
 )
@@ -831,6 +832,7 @@ func GetAwsEc2Client(region string, cacheCfg *cache.Config, maxRetries int) ec2i
 
 	cache.AddCaching(sess, cacheCfg)
 	cacheCfg.SetCacheTTL("ec2", "DescribeSecurityGroups", DescribeSecurityGroupsTTL)
+	cacheCfg.SetCacheTTL("ec2", "DescribeSubnets", DescribeSubnetsTTL)
 	sess.Handlers.Complete.PushFront(func(r *request.Request) {
 		ctx := r.HTTPRequest.Context()
 		log.V(1).Info("AWS API call",

--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -45,6 +45,7 @@ type DiscoveredState struct {
 	InstanceProfile               *iam.InstanceProfile
 	Publisher                     kubeprovider.EventPublisher
 	Cluster                       *eks.Cluster
+	VPCId                         string
 }
 
 func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
@@ -107,6 +108,9 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 		return errors.Wrap(err, "failed to describe cluster")
 	}
 	state.SetCluster(cluster)
+
+	vpcId := aws.StringValue(cluster.ResourcesVpcConfig.VpcId)
+	state.SetVPCId(vpcId)
 
 	// find all owned scaling groups
 	ownedScalingGroups := ctx.findOwnedScalingGroups(scalingGroups)
@@ -199,6 +203,14 @@ func (d *DiscoveredState) GetScalingGroup() *autoscaling.Group {
 
 func (d *DiscoveredState) SetCluster(cluster *eks.Cluster) {
 	d.Cluster = cluster
+}
+
+func (d *DiscoveredState) SetVPCId(id string) {
+	d.VPCId = id
+}
+
+func (d *DiscoveredState) GetVPCId() string {
+	return d.VPCId
 }
 
 func (d *DiscoveredState) GetClusterVersion() string {

--- a/controllers/provisioners/eks/create.go
+++ b/controllers/provisioners/eks/create.go
@@ -65,7 +65,6 @@ func (ctx *EksInstanceGroupContext) CreateScalingGroup(lcName string) error {
 	var (
 		instanceGroup = ctx.GetInstanceGroup()
 		spec          = instanceGroup.GetEKSSpec()
-		configuration = instanceGroup.GetEKSConfiguration()
 		state         = ctx.GetDiscoveredState()
 		asgName       = ctx.ResourcePrefix
 		tags          = ctx.GetAddedTags(asgName)
@@ -81,7 +80,7 @@ func (ctx *EksInstanceGroupContext) CreateScalingGroup(lcName string) error {
 		LaunchConfigurationName: aws.String(lcName),
 		MinSize:                 aws.Int64(spec.GetMinSize()),
 		MaxSize:                 aws.Int64(spec.GetMaxSize()),
-		VPCZoneIdentifier:       aws.String(common.ConcatenateList(configuration.GetSubnets(), ",")),
+		VPCZoneIdentifier:       aws.String(common.ConcatenateList(ctx.ResolveSubnets(), ",")),
 		Tags:                    tags,
 	})
 	if err != nil {

--- a/controllers/provisioners/eks/create_test.go
+++ b/controllers/provisioners/eks/create_test.go
@@ -40,9 +40,10 @@ func TestCreateManagedRolePositive(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 	state := ctx.GetDiscoveredState()
 	state.SetCluster(&eks.Cluster{Version: aws.String("1.15")})
@@ -76,9 +77,10 @@ func TestCreateLaunchConfigurationPositive(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// Skip role creation
@@ -118,9 +120,10 @@ func TestCreateScalingGroupPositive(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// skip role creation
@@ -159,9 +162,10 @@ func TestCreateNoOp(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// skip role creation
@@ -199,9 +203,10 @@ func TestCreateManagedRoleNegative(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// Mock role/profile do not exist so they are always created
@@ -247,9 +252,10 @@ func TestCreateLaunchConfigNegative(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ig.GetEKSConfiguration().SetRoleName("some-role")
@@ -287,9 +293,10 @@ func TestCreateAutoScalingGroupNegative(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ig.GetEKSConfiguration().SetRoleName("some-role")

--- a/controllers/provisioners/eks/delete_test.go
+++ b/controllers/provisioners/eks/delete_test.go
@@ -39,9 +39,10 @@ func TestDeletePositive(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ctx.SetDiscoveredState(&DiscoveredState{
@@ -67,9 +68,10 @@ func TestDeleteManagedRoleNegative(t *testing.T) {
 		asgMock       = NewAutoScalingMocker()
 		iamMock       = NewIamMocker()
 		eksMock       = NewEksMocker()
+		ec2Mock       = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ctx.SetDiscoveredState(&DiscoveredState{
@@ -99,9 +101,10 @@ func TestDeleteLaunchConfigurationNegative(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ctx.SetDiscoveredState(&DiscoveredState{
@@ -129,9 +132,10 @@ func TestDeleteAutoScalingGroupNegative(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ctx.SetDiscoveredState(&DiscoveredState{
@@ -157,9 +161,10 @@ func TestRemoveAuthRoleNegative(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// two instancegroups with same role arn

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -46,9 +46,8 @@ func (ctx *EksInstanceGroupContext) GetLaunchConfigurationInput(name string) *au
 		args                  = ctx.GetBootstrapArgs()
 		preScript, postScript = ctx.GetUserDataStages()
 		userData              = ctx.AwsWorker.GetBasicUserData(clusterName, args, preScript, postScript)
+		sgs                   = ctx.ResolveSecurityGroups()
 	)
-
-	sgs := ctx.ResolveSecurityGroups()
 
 	input := &autoscaling.CreateLaunchConfigurationInput{
 		LaunchConfigurationName: aws.String(name),

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -48,13 +48,15 @@ func (ctx *EksInstanceGroupContext) GetLaunchConfigurationInput(name string) *au
 		userData              = ctx.AwsWorker.GetBasicUserData(clusterName, args, preScript, postScript)
 	)
 
+	sgs := ctx.ResolveSecurityGroups()
+
 	input := &autoscaling.CreateLaunchConfigurationInput{
 		LaunchConfigurationName: aws.String(name),
 		IamInstanceProfile:      instanceProfile.Arn,
 		ImageId:                 aws.String(configuration.Image),
 		InstanceType:            aws.String(configuration.InstanceType),
 		KeyName:                 aws.String(configuration.KeyPairName),
-		SecurityGroups:          aws.StringSlice(configuration.NodeSecurityGroups),
+		SecurityGroups:          aws.StringSlice(sgs),
 		BlockDeviceMappings:     devices,
 		UserData:                aws.String(userData),
 	}
@@ -64,6 +66,64 @@ func (ctx *EksInstanceGroupContext) GetLaunchConfigurationInput(name string) *au
 	}
 
 	return input
+}
+
+func (ctx *EksInstanceGroupContext) ResolveSubnets() []string {
+	var (
+		instanceGroup = ctx.GetInstanceGroup()
+		configuration = instanceGroup.GetEKSConfiguration()
+		state         = ctx.GetDiscoveredState()
+		resolved      = make([]string, 0)
+	)
+
+	for _, s := range configuration.GetSubnets() {
+		if strings.HasPrefix(s, "subnet-") {
+			resolved = append(resolved, s)
+			continue
+		}
+
+		sn, err := ctx.AwsWorker.SubnetByName(s, state.GetVPCId())
+		if err != nil {
+			ctx.Log.Error(err, "failed to resolve subnet id by name", "subnet", s)
+			continue
+		}
+		if sn == nil {
+			ctx.Log.Error(errors.New("subnet not found"), "failed to resolve subnet by name", "subnet", s)
+			continue
+		}
+		resolved = append(resolved, aws.StringValue(sn.SubnetId))
+	}
+
+	return resolved
+}
+
+func (ctx *EksInstanceGroupContext) ResolveSecurityGroups() []string {
+	var (
+		instanceGroup = ctx.GetInstanceGroup()
+		configuration = instanceGroup.GetEKSConfiguration()
+		state         = ctx.GetDiscoveredState()
+		resolved      = make([]string, 0)
+	)
+
+	for _, g := range configuration.GetSecurityGroups() {
+		if strings.HasPrefix(g, "sg-") {
+			resolved = append(resolved, g)
+			continue
+		}
+
+		sg, err := ctx.AwsWorker.SecurityGroupByName(g, state.GetVPCId())
+		if err != nil {
+			ctx.Log.Error(err, "failed to resolve security group by name", "security-group", g)
+			continue
+		}
+		if sg == nil {
+			ctx.Log.Error(errors.New("security group not found"), "failed to resolve security group by name", "security-group", g)
+			continue
+		}
+		resolved = append(resolved, aws.StringValue(sg.GroupId))
+	}
+
+	return resolved
 }
 
 func (ctx *EksInstanceGroupContext) GetUserDataStages() (string, string) {

--- a/controllers/provisioners/eks/helpers_test.go
+++ b/controllers/provisioners/eks/helpers_test.go
@@ -21,12 +21,96 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	awsprovider "github.com/keikoproj/instance-manager/controllers/providers/aws"
 	kubeprovider "github.com/keikoproj/instance-manager/controllers/providers/kubernetes"
 	"github.com/onsi/gomega"
+	"github.com/pkg/errors"
 )
+
+func TestResolveSecurityGroups(t *testing.T) {
+	var (
+		g       = gomega.NewGomegaWithT(t)
+		k       = MockKubernetesClientSet()
+		ig      = MockInstanceGroup()
+		config  = ig.GetEKSConfiguration()
+		asgMock = NewAutoScalingMocker()
+		iamMock = NewIamMocker()
+		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
+	)
+
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
+	ctx := MockContext(ig, k, w)
+
+	tests := []struct {
+		requested []string
+		groups    []*ec2.SecurityGroup
+		result    []string
+		withErr   bool
+	}{
+		{requested: []string{"sg-111", "sg-222"}, groups: []*ec2.SecurityGroup{MockSecurityGroup("sg-111", false, ""), MockSecurityGroup("sg-222", false, "")}, result: []string{"sg-111", "sg-222"}, withErr: false},
+		{requested: []string{"my-sg-1", "sg-222"}, groups: []*ec2.SecurityGroup{MockSecurityGroup("sg-111", true, "my-sg-1"), MockSecurityGroup("sg-222", false, "")}, result: []string{"sg-111", "sg-222"}, withErr: false},
+		{requested: []string{"my-sg-1", "my-sg-2"}, groups: []*ec2.SecurityGroup{MockSecurityGroup("sg-111", true, "my-sg-1"), MockSecurityGroup("sg-222", true, "my-sg-2")}, result: []string{"sg-111", "sg-222"}, withErr: false},
+		{requested: []string{"my-sg-1"}, groups: []*ec2.SecurityGroup{MockSecurityGroup("sg-111", true, "my-sg-1")}, result: []string{}, withErr: true},
+		{requested: []string{"my-sg-1", "my-sg-2"}, groups: []*ec2.SecurityGroup{MockSecurityGroup("sg-111", true, "my-sg-2")}, result: []string{"sg-111"}, withErr: false},
+	}
+
+	for i, tc := range tests {
+		t.Logf("Test #%v - %+v", i, tc)
+		config.NodeSecurityGroups = tc.requested
+		ec2Mock.DescribeSecurityGroupsErr = nil
+		ec2Mock.SecurityGroups = tc.groups
+		if tc.withErr {
+			ec2Mock.DescribeSecurityGroupsErr = errors.New("an error occured")
+		}
+		groups := ctx.ResolveSecurityGroups()
+		g.Expect(groups).To(gomega.Equal(tc.result))
+	}
+}
+
+func TestResolveSubnets(t *testing.T) {
+	var (
+		g       = gomega.NewGomegaWithT(t)
+		k       = MockKubernetesClientSet()
+		ig      = MockInstanceGroup()
+		config  = ig.GetEKSConfiguration()
+		asgMock = NewAutoScalingMocker()
+		iamMock = NewIamMocker()
+		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
+	)
+
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
+	ctx := MockContext(ig, k, w)
+
+	tests := []struct {
+		requested []string
+		subnets   []*ec2.Subnet
+		result    []string
+		withErr   bool
+	}{
+		{requested: []string{"subnet-111", "subnet-222"}, subnets: []*ec2.Subnet{MockSubnet("subnet-111", false, ""), MockSubnet("subnet-222", false, "")}, result: []string{"subnet-111", "subnet-222"}, withErr: false},
+		{requested: []string{"my-subnet-1", "subnet-222"}, subnets: []*ec2.Subnet{MockSubnet("subnet-111", true, "my-subnet-1"), MockSubnet("subnet-222", false, "")}, result: []string{"subnet-111", "subnet-222"}, withErr: false},
+		{requested: []string{"my-subnet-1", "my-subnet-2"}, subnets: []*ec2.Subnet{MockSubnet("subnet-111", true, "my-subnet-1"), MockSubnet("subnet-222", true, "my-subnet-2")}, result: []string{"subnet-111", "subnet-222"}, withErr: false},
+		{requested: []string{"my-subnet-1"}, subnets: []*ec2.Subnet{MockSubnet("subnet-111", true, "my-subnet-1")}, result: []string{}, withErr: true},
+		{requested: []string{"my-subnet-1", "my-subnet-2"}, subnets: []*ec2.Subnet{MockSubnet("subnet-111", true, "my-subnet-2")}, result: []string{"subnet-111"}, withErr: false},
+	}
+
+	for i, tc := range tests {
+		t.Logf("Test #%v - %+v", i, tc)
+		config.Subnets = tc.requested
+		ec2Mock.Subnets = tc.subnets
+		ec2Mock.DescribeSubnetsErr = nil
+		if tc.withErr {
+			ec2Mock.DescribeSubnetsErr = errors.New("an error occured")
+		}
+		groups := ctx.ResolveSubnets()
+		g.Expect(groups).To(gomega.Equal(tc.result))
+	}
+}
 
 func TestGetDisabledMetrics(t *testing.T) {
 	var (
@@ -36,9 +120,10 @@ func TestGetDisabledMetrics(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// No disable required
@@ -95,9 +180,10 @@ func TestGetEnabledMetrics(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// Enable all metrics
@@ -140,6 +226,7 @@ func TestGetLabelList(t *testing.T) {
 		asgMock                    = NewAutoScalingMocker()
 		iamMock                    = NewIamMocker()
 		eksMock                    = NewEksMocker()
+		ec2Mock                    = NewEc2Mocker()
 		expectedLabels115          = []string{"node-role.kubernetes.io/instance-group-1=\"\"", "node.kubernetes.io/role=instance-group-1"}
 		expectedLabels116          = []string{"node.kubernetes.io/role=instance-group-1"}
 		expectedLabelsWithCustom   = []string{"custom.kubernetes.io=customlabel", "node.kubernetes.io/role=instance-group-1"}
@@ -149,7 +236,7 @@ func TestGetLabelList(t *testing.T) {
 		defaultLifecycleLable      = "instancemgr.keikoproj.io/lifecycle=normal"
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	tests := []struct {
@@ -203,9 +290,10 @@ func TestGetUserDataStages(t *testing.T) {
 		asgMock       = NewAutoScalingMocker()
 		iamMock       = NewIamMocker()
 		eksMock       = NewEksMocker()
+		ec2Mock       = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	tests := []struct {

--- a/controllers/provisioners/eks/state_test.go
+++ b/controllers/provisioners/eks/state_test.go
@@ -35,9 +35,10 @@ func TestStateDiscovery(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	tests := []struct {
@@ -85,9 +86,10 @@ func TestIsReady(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	tests := []struct {

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -84,7 +84,6 @@ func (ctx *EksInstanceGroupContext) UpdateScalingGroup() error {
 	var (
 		instanceGroup = ctx.GetInstanceGroup()
 		spec          = instanceGroup.GetEKSSpec()
-		configuration = instanceGroup.GetEKSConfiguration()
 		status        = instanceGroup.GetStatus()
 		state         = ctx.GetDiscoveredState()
 		scalingGroup  = state.GetScalingGroup()
@@ -99,7 +98,7 @@ func (ctx *EksInstanceGroupContext) UpdateScalingGroup() error {
 			LaunchConfigurationName: aws.String(state.GetActiveLaunchConfigurationName()),
 			MinSize:                 aws.Int64(spec.GetMinSize()),
 			MaxSize:                 aws.Int64(spec.GetMaxSize()),
-			VPCZoneIdentifier:       aws.String(common.ConcatenateList(configuration.GetSubnets(), ",")),
+			VPCZoneIdentifier:       aws.String(common.ConcatenateList(ctx.ResolveSubnets(), ",")),
 		})
 		if err != nil {
 			return err
@@ -186,12 +185,11 @@ func (ctx *EksInstanceGroupContext) ScalingGroupUpdateNeeded() bool {
 	var (
 		instanceGroup  = ctx.GetInstanceGroup()
 		spec           = instanceGroup.GetEKSSpec()
-		configuration  = instanceGroup.GetEKSConfiguration()
 		state          = ctx.GetDiscoveredState()
 		scalingGroup   = state.GetScalingGroup()
 		zoneIdentifier = aws.StringValue(scalingGroup.VPCZoneIdentifier)
 		groupSubnets   = strings.Split(zoneIdentifier, ",")
-		specSubnets    = configuration.GetSubnets()
+		specSubnets    = ctx.ResolveSubnets()
 	)
 
 	if state.GetActiveLaunchConfigurationName() != aws.StringValue(scalingGroup.LaunchConfigurationName) {

--- a/controllers/provisioners/eks/update_test.go
+++ b/controllers/provisioners/eks/update_test.go
@@ -39,9 +39,10 @@ func TestUpdateScalingGroupPositive(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ctx.SetDiscoveredState(&DiscoveredState{
@@ -137,9 +138,10 @@ func TestUpdateWithDriftRotationPositive(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	mockScalingGroup := &autoscaling.Group{
@@ -210,9 +212,10 @@ func TestUpdateWithRotationPositive(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ctx.SetDiscoveredState(&DiscoveredState{
@@ -287,9 +290,10 @@ func TestLaunchConfigurationDrifted(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	ctx.SetDiscoveredState(&DiscoveredState{
@@ -363,9 +367,10 @@ func TestUpdateScalingGroupNegative(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 	ig.GetEKSConfiguration().SetMetricsCollection([]string{"GroupMinSize", "GroupMaxSize", "GroupDesiredCapacity"})
 
@@ -436,9 +441,10 @@ func TestScalingGroupUpdatePredicate(t *testing.T) {
 		asgMock       = NewAutoScalingMocker()
 		iamMock       = NewIamMocker()
 		eksMock       = NewEksMocker()
+		ec2Mock       = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 	spec.MinSize = int64(3)
 	spec.MaxSize = int64(6)
@@ -486,9 +492,10 @@ func TestUpdateManagedPolicies(t *testing.T) {
 		asgMock       = NewAutoScalingMocker()
 		iamMock       = NewIamMocker()
 		eksMock       = NewEksMocker()
+		ec2Mock       = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	tests := []struct {

--- a/controllers/provisioners/eks/upgrade_test.go
+++ b/controllers/provisioners/eks/upgrade_test.go
@@ -112,9 +112,10 @@ func TestUpgradeInvalidStrategy(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// assume initial state of modifying
@@ -134,9 +135,10 @@ func TestBootstrapNodes(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	// assume initial state of modifying
@@ -155,9 +157,10 @@ func TestUpgradeCRDStrategy(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 	ctx.SetDiscoveredState(&DiscoveredState{
 		Publisher: kubeprovider.EventPublisher{
@@ -219,9 +222,10 @@ func TestUpgradeRollingUpdateStrategyPositive(t *testing.T) {
 		asgMock = NewAutoScalingMocker()
 		iamMock = NewIamMocker()
 		eksMock = NewEksMocker()
+		ec2Mock = NewEc2Mocker()
 	)
 
-	w := MockAwsWorker(asgMock, iamMock, eksMock)
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 
 	tests := []struct {

--- a/docs/EKS.md
+++ b/docs/EKS.md
@@ -25,8 +25,8 @@ spec:
       keyPairName: <string> : must match the name of an EC2 Key Pair (required)
       image: <string> : must match the ID of an EKS AMI (required)
       instanceType: <string> : must match the type of an EC2 instance (required)
-      securityGroups: <[]string> : must match existing security group IDs (required)
-      subnets: <[]string> : must match existing subnet IDs (required)
+      securityGroups: <[]string> : must match existing security group IDs or Name (by value of tag "Name") (required)
+      subnets: <[]string> : must match existing subnet IDs or Name (by value of tag "Name") (required)
 
       # customize EBS volumes
       volumes: <[]NodeVolume> : list of NodeVolume objects

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,6 +51,8 @@ The below are the minimum required policies needed to run the basic operations o
 iam:GetRole
 iam:GetInstanceProfile
 iam:PassRole
+ec2:DescribeSecurityGroups
+ec2:DescribeSubnets
 autoscaling:DescribeAutoScalingGroups
 autoscaling:UpdateAutoScalingGroup
 autoscaling:TerminateInstanceInAutoScalingGroup

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func main() {
 	cacheCfg := cache.NewConfig(aws.CacheDefaultTTL, aws.CacheMaxItems, aws.CacheItemsToPrune)
 
 	awsWorker := aws.AwsWorker{
+		Ec2Client: aws.GetAwsEc2Client(awsRegion, cacheCfg, maxAPIRetries),
 		IamClient: aws.GetAwsIamClient(awsRegion, cacheCfg, maxAPIRetries),
 		AsgClient: aws.GetAwsAsgClient(awsRegion, cacheCfg, maxAPIRetries),
 		EksClient: aws.GetAwsEksClient(awsRegion, cacheCfg, maxAPIRetries),


### PR DESCRIPTION
Fixes #156 

This adds support for using "Name" tag of resource instead of ID for Subnets & Security Groups if provided.

- [x] Functional test passing