### PR TITLE
Refactor - Abstract ScalingConfiguration

### DIFF
--- a/controllers/common/utils.go
+++ b/controllers/common/utils.go
@@ -38,6 +38,15 @@ func ContainsString(slice []string, s string) bool {
 	return false
 }
 
+func ContainsEqualFoldSubstring(str, substr string) bool {
+	x := strings.ToLower(str)
+	y := strings.ToLower(substr)
+	if strings.Contains(x, y) {
+		return true
+	}
+	return false
+}
+
 // ContainsEqualFold returns true if a given slice 'slice' contains string 's' under unicode case-folding
 func ContainsEqualFold(slice []string, s string) bool {
 	for _, item := range slice {

--- a/controllers/instancegroup_controller.go
+++ b/controllers/instancegroup_controller.go
@@ -17,6 +17,7 @@ package controllers
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"time"
 
@@ -121,7 +122,7 @@ func (r *InstanceGroupReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		Log:           r.Log,
 	}
 
-	if r.ConfigMap != nil {
+	if !reflect.DeepEqual(r.ConfigMap, &corev1.ConfigMap{}) {
 		var defaultConfig *provisioners.ProvisionerConfiguration
 		if defaultConfig, err = provisioners.NewProvisionerConfiguration(r.ConfigMap, instanceGroup); err != nil {
 			return ctrl.Result{}, err

--- a/controllers/interface.go
+++ b/controllers/interface.go
@@ -54,7 +54,6 @@ func HandleReconcileRequest(d CloudDeployer) error {
 
 	// CRUD Nodes Upgrade Strategy
 	if d.GetState() == v1alpha.ReconcileInitUpgrade {
-		// CF Update finished & upgrade is not 'rollingUpdate'.
 		err = d.UpgradeNodes()
 		if err != nil {
 			return err

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -108,6 +108,8 @@ var (
 const (
 	IAMPolicyPrefix = "arn:aws:iam::aws:policy"
 	IAMARNPrefix    = "arn:aws:iam::"
+
+	LaunchConfigurationNotFoundErrorMessage = "Launch configuration name not found"
 )
 
 type EKSUserData struct {

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -107,6 +107,7 @@ var (
 
 const (
 	IAMPolicyPrefix = "arn:aws:iam::aws:policy"
+	IAMARNPrefix    = "arn:aws:iam::"
 )
 
 type EKSUserData struct {

--- a/controllers/provisioners/config.go
+++ b/controllers/provisioners/config.go
@@ -105,8 +105,6 @@ func (c *ProvisionerConfiguration) Unmarshal(cm *corev1.ConfigMap) error {
 }
 
 func (c *ProvisionerConfiguration) SetDefaults() error {
-
-	log.Info("applying managed defaults from configmap")
 	unstructuredInstanceGroup, err := runtime.DefaultUnstructuredConverter.ToUnstructured(c.InstanceGroup)
 	if err != nil {
 		return errors.Wrap(err, "failed to convert instance group to unstructured")

--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -222,9 +222,6 @@ func (d *DiscoveredState) GetAttachedPolicies() []*iam.AttachedPolicy {
 func (d *DiscoveredState) HasRole() bool {
 	return d.IAMRole != nil
 }
-func (d *DiscoveredState) HasInstanceProfile() bool {
-	return d.InstanceProfile != nil
-}
 func (d *DiscoveredState) HasScalingGroup() bool {
 	return d.ScalingGroup != nil
 }

--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -17,10 +17,10 @@ package eks
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	kubeprovider "github.com/keikoproj/instance-manager/controllers/providers/kubernetes"
+	"github.com/keikoproj/instance-manager/controllers/provisioners/eks/scaling"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -32,20 +32,18 @@ import (
 )
 
 type DiscoveredState struct {
-	Provisioned                   bool
-	NodesReady                    bool
-	ClusterNodes                  *corev1.NodeList
-	OwnedScalingGroups            []*autoscaling.Group
-	ScalingGroup                  *autoscaling.Group
-	LaunchConfigurations          []*autoscaling.LaunchConfiguration
-	LaunchConfiguration           *autoscaling.LaunchConfiguration
-	ActiveLaunchConfigurationName string
-	IAMRole                       *iam.Role
-	AttachedPolicies              []*iam.AttachedPolicy
-	InstanceProfile               *iam.InstanceProfile
-	Publisher                     kubeprovider.EventPublisher
-	Cluster                       *eks.Cluster
-	VPCId                         string
+	Provisioned          bool
+	NodesReady           bool
+	ClusterNodes         *corev1.NodeList
+	OwnedScalingGroups   []*autoscaling.Group
+	ScalingGroup         *autoscaling.Group
+	ScalingConfiguration scaling.Configuration
+	IAMRole              *iam.Role
+	AttachedPolicies     []*iam.AttachedPolicy
+	InstanceProfile      *iam.InstanceProfile
+	Publisher            kubeprovider.EventPublisher
+	Cluster              *eks.Cluster
+	VPCId                string
 }
 
 func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
@@ -63,6 +61,10 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 		Name:            instanceGroup.GetName(),
 		UID:             instanceGroup.GetUID(),
 		ResourceVersion: instanceGroup.GetResourceVersion(),
+	}
+
+	state.ScalingConfiguration = &scaling.LaunchConfiguration{
+		AwsWorker: ctx.AwsWorker,
 	}
 
 	nodes, err := ctx.KubernetesClient.Kubernetes.CoreV1().Nodes().List(metav1.ListOptions{})
@@ -124,13 +126,6 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 		return nil
 	}
 
-	launchConfigurations, err := ctx.AwsWorker.DescribeAutoscalingLaunchConfigs()
-	if err != nil {
-		return errors.Wrap(err, "failed to describe autoscaling groups")
-	}
-
-	ctx.DiscoveredState.SetLaunchConfigurations(launchConfigurations)
-
 	state.SetProvisioned(true)
 	state.SetScalingGroup(targetScalingGroup)
 
@@ -139,35 +134,21 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 	status.SetCurrentMin(int(aws.Int64Value(targetScalingGroup.MinSize)))
 	status.SetCurrentMax(int(aws.Int64Value(targetScalingGroup.MaxSize)))
 
-	// cache the launch configuration we are reconciling for if it exists
-	for _, lc := range launchConfigurations {
-		lcName := aws.StringValue(lc.LaunchConfigurationName)
-		if aws.StringValue(lc.LaunchConfigurationName) == aws.StringValue(targetScalingGroup.LaunchConfigurationName) {
-			state.SetLaunchConfiguration(lc)
-			state.SetActiveLaunchConfigurationName(lcName)
-			status.SetActiveLaunchConfigurationName(lcName)
-		}
+	state.ScalingConfiguration, err = scaling.NewLaunchConfiguration(instanceGroup.NamespacedName(), ctx.AwsWorker, &scaling.DiscoverConfigurationInput{
+		ScalingGroup: targetScalingGroup,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to discover launch configurations")
 	}
+	configName := state.ScalingConfiguration.Name()
+	status.SetActiveLaunchConfigurationName(configName)
 
 	// delete old launch configurations
-	sortedConfigs := ctx.GetTimeSortedLaunchConfigurations()
-	var deletable []*autoscaling.LaunchConfiguration
-	if len(sortedConfigs) > defaultLaunchConfigurationRetention {
-		d := len(sortedConfigs) - defaultLaunchConfigurationRetention
-		deletable = sortedConfigs[:d]
-	}
-
-	for _, d := range deletable {
-		name := aws.StringValue(d.LaunchConfigurationName)
-		if strings.EqualFold(name, state.GetActiveLaunchConfigurationName()) {
-			// never try to delete the active launch config
-			continue
-		}
-		ctx.Log.Info("deleting old launch configuration", "instancegroup", instanceGroup.GetName(), "name", name)
-		if err := ctx.AwsWorker.DeleteLaunchConfig(name); err != nil {
-			ctx.Log.Error(err, "failed to delete launch configuration", "instancegroup", instanceGroup.GetName(), "name", name)
-		}
-	}
+	state.ScalingConfiguration.Delete(&scaling.DeleteConfigurationInput{
+		Name:      configName,
+		Prefix:    ctx.ResourcePrefix,
+		DeleteAll: false,
+	})
 
 	if status.GetNodesReadyCondition() == corev1.ConditionTrue {
 		state.SetNodesReady(true)
@@ -226,6 +207,9 @@ func (d *DiscoveredState) SetOwnedScalingGroups(groups []*autoscaling.Group) {
 func (d *DiscoveredState) GetOwnedScalingGroups() []*autoscaling.Group {
 	return d.OwnedScalingGroups
 }
+func (d *DiscoveredState) GetScalingConfiguration() scaling.Configuration {
+	return d.ScalingConfiguration
+}
 func (d *DiscoveredState) SetAttachedPolicies(policies []*iam.AttachedPolicy) {
 	d.AttachedPolicies = policies
 }
@@ -234,29 +218,6 @@ func (d *DiscoveredState) GetAttachedPolicies() []*iam.AttachedPolicy {
 		d.AttachedPolicies = []*iam.AttachedPolicy{}
 	}
 	return d.AttachedPolicies
-}
-func (d *DiscoveredState) SetLaunchConfiguration(lc *autoscaling.LaunchConfiguration) {
-	if lc != nil {
-		d.LaunchConfiguration = lc
-	}
-}
-func (d *DiscoveredState) GetLaunchConfiguration() *autoscaling.LaunchConfiguration {
-	return d.LaunchConfiguration
-}
-func (d *DiscoveredState) GetLaunchConfigurations() []*autoscaling.LaunchConfiguration {
-	return d.LaunchConfigurations
-}
-func (d *DiscoveredState) SetLaunchConfigurations(configs []*autoscaling.LaunchConfiguration) {
-	d.LaunchConfigurations = configs
-}
-func (d *DiscoveredState) SetActiveLaunchConfigurationName(name string) {
-	d.ActiveLaunchConfigurationName = name
-}
-func (d *DiscoveredState) GetActiveLaunchConfigurationName() string {
-	return d.ActiveLaunchConfigurationName
-}
-func (d *DiscoveredState) HasLaunchConfiguration() bool {
-	return d.LaunchConfiguration != nil
 }
 func (d *DiscoveredState) HasRole() bool {
 	return d.IAMRole != nil

--- a/controllers/provisioners/eks/cloud_test.go
+++ b/controllers/provisioners/eks/cloud_test.go
@@ -92,13 +92,16 @@ func TestCloudDiscoveryPositive(t *testing.T) {
 
 	err := ctx.CloudDiscovery()
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	lc := state.ScalingConfiguration.Resource().(*autoscaling.LaunchConfiguration)
+
 	g.Expect(state.GetRole()).To(gomega.Equal(iamMock.Role))
 	g.Expect(state.GetInstanceProfile()).To(gomega.Equal(iamMock.InstanceProfile))
 	g.Expect(state.GetOwnedScalingGroups()).To(gomega.Equal(asgMock.AutoScalingGroups))
 	g.Expect(state.IsProvisioned()).To(gomega.BeTrue())
 	g.Expect(state.GetScalingGroup()).To(gomega.Equal(ownedScalingGroup))
-	g.Expect(state.GetLaunchConfiguration()).To(gomega.Equal(launchConfig))
-	g.Expect(state.GetActiveLaunchConfigurationName()).To(gomega.Equal(launchConfigName))
+	g.Expect(lc).To(gomega.Equal(launchConfig))
+	g.Expect(state.ScalingConfiguration.Name()).To(gomega.Equal(launchConfigName))
 	g.Expect(state.GetVPCId()).To(gomega.Equal(vpcId))
 	g.Expect(status.GetNodesArn()).To(gomega.Equal(aws.StringValue(iamMock.Role.Arn)))
 	g.Expect(status.GetActiveScalingGroupName()).To(gomega.Equal(ownedScalingGroupName))

--- a/controllers/provisioners/eks/create.go
+++ b/controllers/provisioners/eks/create.go
@@ -36,7 +36,6 @@ func (ctx *EksInstanceGroupContext) Create() error {
 		state                 = ctx.GetDiscoveredState()
 		scalingConfig         = state.GetScalingConfiguration()
 		configuration         = instanceGroup.GetEKSConfiguration()
-		instanceProfile       = state.GetInstanceProfile()
 		args                  = ctx.GetBootstrapArgs()
 		preScript, postScript = ctx.GetUserDataStages()
 		clusterName           = configuration.GetClusterName()
@@ -52,6 +51,7 @@ func (ctx *EksInstanceGroupContext) Create() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create scaling group role")
 	}
+	instanceProfile := state.GetInstanceProfile()
 
 	if !scalingConfig.Provisioned() {
 		configName = fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -196,21 +196,6 @@ func (ctx *EksInstanceGroupContext) UpdateScalingProcesses(asgName string) error
 	return nil
 }
 
-func (ctx *EksInstanceGroupContext) GetBlockDeviceList() []*autoscaling.BlockDeviceMapping {
-	var (
-		devices       []*autoscaling.BlockDeviceMapping
-		instanceGroup = ctx.GetInstanceGroup()
-		configuration = instanceGroup.GetEKSConfiguration()
-	)
-
-	customVolumes := configuration.GetVolumes()
-	for _, v := range customVolumes {
-		devices = append(devices, ctx.AwsWorker.GetBasicBlockDevice(v.Name, v.Type, v.SnapshotID, v.Size, v.Iops, v.DeleteOnTermination, v.Encrypted))
-	}
-
-	return devices
-}
-
 func (ctx *EksInstanceGroupContext) GetTaintList() []string {
 	var (
 		taintList     []string

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -527,9 +527,12 @@ func (ctx *EksInstanceGroupContext) UpdateMetricsCollection(asgName string) erro
 func (ctx *EksInstanceGroupContext) GetManagedPoliciesList(additionalPolicies []string) []string {
 	managedPolicies := make([]string, 0)
 	for _, name := range additionalPolicies {
-		if strings.HasPrefix(name, awsprovider.IAMPolicyPrefix) {
+		switch {
+		case strings.HasPrefix(name, awsprovider.IAMPolicyPrefix):
 			managedPolicies = append(managedPolicies, name)
-		} else {
+		case strings.HasPrefix(name, awsprovider.IAMARNPrefix):
+			managedPolicies = append(managedPolicies, name)
+		default:
 			managedPolicies = append(managedPolicies, fmt.Sprintf("%s/%s", awsprovider.IAMPolicyPrefix, name))
 		}
 	}
@@ -537,6 +540,7 @@ func (ctx *EksInstanceGroupContext) GetManagedPoliciesList(additionalPolicies []
 	for _, name := range DefaultManagedPolicies {
 		managedPolicies = append(managedPolicies, fmt.Sprintf("%s/%s", awsprovider.IAMPolicyPrefix, name))
 	}
+
 	return managedPolicies
 }
 

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -579,12 +579,3 @@ func (ctx *EksInstanceGroupContext) RemoveAuthRole(arn string) error {
 
 	return common.RemoveAuthConfigMap(ctx.KubernetesClient.Kubernetes, []string{arn})
 }
-
-func IsRetryable(instanceGroup *v1alpha1.InstanceGroup) bool {
-	for _, state := range NonRetryableStates {
-		if state == instanceGroup.GetState() {
-			return false
-		}
-	}
-	return true
-}

--- a/controllers/provisioners/eks/helpers_test.go
+++ b/controllers/provisioners/eks/helpers_test.go
@@ -336,35 +336,3 @@ func TestGetUserDataStages(t *testing.T) {
 		g.Expect(postScript).To(gomega.ConsistOf(tc.postBootstrapScript))
 	}
 }
-
-func TestIsRetryable(t *testing.T) {
-	var (
-		g  = gomega.NewGomegaWithT(t)
-		ig = MockInstanceGroup()
-	)
-
-	tests := []struct {
-		state             v1alpha1.ReconcileState
-		expectedRetryable bool
-	}{
-		{state: v1alpha1.ReconcileErr, expectedRetryable: false},
-		{state: v1alpha1.ReconcileReady, expectedRetryable: false},
-		{state: v1alpha1.ReconcileDeleted, expectedRetryable: false},
-		{state: v1alpha1.ReconcileDeleting, expectedRetryable: true},
-		{state: v1alpha1.ReconcileInit, expectedRetryable: true},
-		{state: v1alpha1.ReconcileInitCreate, expectedRetryable: true},
-		{state: v1alpha1.ReconcileInitDelete, expectedRetryable: true},
-		{state: v1alpha1.ReconcileInitUpdate, expectedRetryable: true},
-		{state: v1alpha1.ReconcileInitUpgrade, expectedRetryable: true},
-		{state: v1alpha1.ReconcileModified, expectedRetryable: true},
-		{state: v1alpha1.ReconcileModifying, expectedRetryable: true},
-	}
-
-	for i, tc := range tests {
-		t.Logf("Test #%v - %+v", i, tc)
-		ig.SetState(tc.state)
-
-		retryable := IsRetryable(ig)
-		g.Expect(retryable).To(gomega.Equal(tc.expectedRetryable))
-	}
-}

--- a/controllers/provisioners/eks/scaling/interface.go
+++ b/controllers/provisioners/eks/scaling/interface.go
@@ -1,0 +1,59 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaling
+
+import (
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/keikoproj/instance-manager/api/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	log = ctrl.Log.WithName("scaling")
+)
+
+type Configuration interface {
+	Name() string
+	Resource() interface{}
+	Create(input *CreateConfigurationInput) error
+	Delete(input *DeleteConfigurationInput) error
+	Discover(input *DiscoverConfigurationInput) error
+	Drifted(input *CreateConfigurationInput) bool
+	Provisioned() bool
+}
+
+type DeleteConfigurationInput struct {
+	Name           string
+	Prefix         string
+	DeleteAll      bool
+	RetainVersions int
+}
+
+type DiscoverConfigurationInput struct {
+	ScalingGroup *autoscaling.Group
+}
+
+type CreateConfigurationInput struct {
+	Name                  string
+	IamInstanceProfileArn string
+	ImageId               string
+	InstanceType          string
+	KeyName               string
+	SecurityGroups        []string
+	Volumes               []v1alpha1.NodeVolume
+	UserData              string
+	SpotPrice             string
+}

--- a/controllers/provisioners/eks/scaling/launchconfig.go
+++ b/controllers/provisioners/eks/scaling/launchconfig.go
@@ -1,0 +1,266 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaling
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/keikoproj/instance-manager/api/v1alpha1"
+	"github.com/keikoproj/instance-manager/controllers/common"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	awsprovider "github.com/keikoproj/instance-manager/controllers/providers/aws"
+	"github.com/pkg/errors"
+)
+
+type LaunchConfiguration struct {
+	awsprovider.AwsWorker
+	OwnerName      string
+	TargetResource *autoscaling.LaunchConfiguration
+	ResourceList   []*autoscaling.LaunchConfiguration
+}
+
+var (
+	DefaultVersionRetention int = 2
+)
+
+func NewLaunchConfiguration(ownerName string, w awsprovider.AwsWorker, input *DiscoverConfigurationInput) (*LaunchConfiguration, error) {
+	lc := &LaunchConfiguration{}
+	lc.AwsWorker = w
+	lc.OwnerName = ownerName
+	if err := lc.Discover(input); err != nil {
+		return lc, errors.Wrap(err, "discovery failed")
+	}
+	return lc, nil
+}
+
+func (lc *LaunchConfiguration) Discover(input *DiscoverConfigurationInput) error {
+	launchConfigurations, err := lc.DescribeAutoscalingLaunchConfigs()
+	if err != nil {
+		return errors.Wrap(err, "failed to describe autoscaling groups")
+	}
+	lc.ResourceList = launchConfigurations
+
+	if input.ScalingGroup == nil {
+		return nil
+	}
+	targetName := aws.StringValue(input.ScalingGroup.LaunchConfigurationName)
+
+	for _, config := range launchConfigurations {
+		name := aws.StringValue(config.LaunchConfigurationName)
+		if strings.EqualFold(name, targetName) {
+			lc.TargetResource = config
+		}
+	}
+
+	return nil
+}
+
+func (lc *LaunchConfiguration) Create(input *CreateConfigurationInput) error {
+	devices := lc.blockDeviceList(input.Volumes)
+	opts := &autoscaling.CreateLaunchConfigurationInput{
+		LaunchConfigurationName: aws.String(input.Name),
+		IamInstanceProfile:      aws.String(input.IamInstanceProfileArn),
+		ImageId:                 aws.String(input.ImageId),
+		InstanceType:            aws.String(input.InstanceType),
+		KeyName:                 aws.String(input.KeyName),
+		SecurityGroups:          aws.StringSlice(input.SecurityGroups),
+		UserData:                aws.String(input.UserData),
+		BlockDeviceMappings:     devices,
+	}
+
+	if !common.StringEmpty(input.SpotPrice) {
+		opts.SpotPrice = aws.String(input.SpotPrice)
+	}
+
+	if err := lc.CreateLaunchConfig(opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (lc *LaunchConfiguration) Delete(input *DeleteConfigurationInput) error {
+	if input.RetainVersions == 0 {
+		input.RetainVersions = DefaultVersionRetention
+	}
+
+	prefixedConfigs := prefixedConfigurations(lc.ResourceList, input.Prefix)
+	sortedConfigs := sortedConfigurations(prefixedConfigs)
+
+	var deletable []*autoscaling.LaunchConfiguration
+	if len(sortedConfigs) > input.RetainVersions {
+		d := len(sortedConfigs) - input.RetainVersions
+		deletable = sortedConfigs[:d]
+	}
+
+	if input.DeleteAll {
+		deletable = prefixedConfigs
+	}
+
+	for _, d := range deletable {
+		name := aws.StringValue(d.LaunchConfigurationName)
+		if !input.DeleteAll && strings.EqualFold(name, input.Name) {
+			continue
+		}
+
+		log.Info("deleting launch configuration", "instancegroup", lc.OwnerName, "name", name)
+
+		if err := lc.DeleteLaunchConfig(name); err != nil {
+			return errors.Wrap(err, "failed to delete launch configuration")
+		}
+	}
+
+	return nil
+}
+
+func (lc *LaunchConfiguration) Drifted(input *CreateConfigurationInput) bool {
+	var (
+		existingConfig = lc.TargetResource
+		drift          bool
+	)
+
+	if existingConfig == nil {
+		log.Info("detected drift", "reason", "launchconfig does not exist", "instancegroup", lc.OwnerName)
+		return true
+	}
+
+	if aws.StringValue(existingConfig.ImageId) != input.ImageId {
+		log.Info("detected drift", "reason", "image-id has changed", "instancegroup", lc.OwnerName,
+			"previousValue", aws.StringValue(existingConfig.ImageId),
+			"newValue", input.ImageId,
+		)
+		drift = true
+	}
+
+	if aws.StringValue(existingConfig.InstanceType) != input.InstanceType {
+		log.Info("detected drift", "reason", "instance-type has changed", "instancegroup", lc.OwnerName,
+			"previousValue", aws.StringValue(existingConfig.InstanceType),
+			"newValue", input.InstanceType,
+		)
+		drift = true
+	}
+
+	if aws.StringValue(existingConfig.IamInstanceProfile) != input.IamInstanceProfileArn {
+		log.Info("detected drift", "reason", "instance-profile has changed", "instancegroup", lc.OwnerName,
+			"previousValue", aws.StringValue(existingConfig.IamInstanceProfile),
+			"newValue", input.IamInstanceProfileArn,
+		)
+		drift = true
+	}
+
+	if !common.StringSliceEquals(aws.StringValueSlice(existingConfig.SecurityGroups), input.SecurityGroups) {
+		log.Info("detected drift", "reason", "security-groups has changed", "instancegroup", lc.OwnerName,
+			"previousValue", aws.StringValueSlice(existingConfig.SecurityGroups),
+			"newValue", input.SecurityGroups,
+		)
+		drift = true
+	}
+
+	if aws.StringValue(existingConfig.SpotPrice) != input.SpotPrice {
+		log.Info("detected drift", "reason", "spot-price has changed", "instancegroup", lc.OwnerName,
+			"previousValue", aws.StringValue(existingConfig.SpotPrice),
+			"newValue", input.SpotPrice,
+		)
+		drift = true
+	}
+
+	if aws.StringValue(existingConfig.KeyName) != input.KeyName {
+		log.Info("detected drift", "reason", "key-pair has changed", "instancegroup", lc.OwnerName,
+			"previousValue", aws.StringValue(existingConfig.KeyName),
+			"newValue", input.KeyName,
+		)
+		drift = true
+	}
+
+	if aws.StringValue(existingConfig.UserData) != input.UserData {
+		log.Info("detected drift", "reason", "user-data has changed", "instancegroup", lc.OwnerName,
+			"previousValue", aws.StringValue(existingConfig.UserData),
+			"newValue", input.UserData,
+		)
+		drift = true
+	}
+
+	devices := lc.blockDeviceList(input.Volumes)
+	if !reflect.DeepEqual(existingConfig.BlockDeviceMappings, devices) {
+		log.Info("detected drift", "reason", "volumes have changed", "instancegroup", lc.OwnerName,
+			"previousValue", existingConfig.BlockDeviceMappings,
+			"newValue", devices,
+		)
+		drift = true
+	}
+
+	if !drift {
+		log.Info("no drift detected", "instancegroup", lc.OwnerName)
+	}
+
+	return drift
+}
+
+func (lc *LaunchConfiguration) Provisioned() bool {
+	return lc.TargetResource != nil
+}
+
+func (lc *LaunchConfiguration) Resource() interface{} {
+	return lc.TargetResource
+}
+
+func (lc *LaunchConfiguration) Name() string {
+	if lc.TargetResource == nil {
+		return ""
+	}
+	return aws.StringValue(lc.TargetResource.LaunchConfigurationName)
+}
+
+func (lc *LaunchConfiguration) blockDeviceList(volumes []v1alpha1.NodeVolume) []*autoscaling.BlockDeviceMapping {
+	var devices []*autoscaling.BlockDeviceMapping
+	for _, v := range volumes {
+		devices = append(devices, lc.GetBasicBlockDevice(v.Name, v.Type, v.SnapshotID, v.Size, v.Iops, v.DeleteOnTermination, v.Encrypted))
+	}
+
+	return devices
+}
+
+func prefixedConfigurations(configs []*autoscaling.LaunchConfiguration, prefix string) []*autoscaling.LaunchConfiguration {
+	prefixed := []*autoscaling.LaunchConfiguration{}
+	for _, lc := range configs {
+		name := aws.StringValue(lc.LaunchConfigurationName)
+		if strings.HasPrefix(name, prefix) {
+			prefixed = append(prefixed, lc)
+		}
+	}
+	return prefixed
+}
+
+func sortedConfigurations(configs []*autoscaling.LaunchConfiguration) []*autoscaling.LaunchConfiguration {
+	// sort matching launch configs by created time
+	sort.Slice(configs, func(i, j int) bool {
+		ti := configs[i].CreatedTime
+		tj := configs[j].CreatedTime
+		if tj == nil {
+			return true
+		}
+		if ti == nil {
+			return false
+		}
+		return ti.UnixNano() < tj.UnixNano()
+	})
+
+	return configs
+}

--- a/controllers/provisioners/eks/scaling/launchconfig_test.go
+++ b/controllers/provisioners/eks/scaling/launchconfig_test.go
@@ -1,0 +1,452 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scaling
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	"github.com/keikoproj/instance-manager/api/v1alpha1"
+	awsprovider "github.com/keikoproj/instance-manager/controllers/providers/aws"
+
+	"github.com/onsi/gomega"
+)
+
+type MockAutoScalingClient struct {
+	autoscalingiface.AutoScalingAPI
+	DescribeLaunchConfigurationsErr    error
+	CreateLaunchConfigurationErr       error
+	DeleteLaunchConfigurationErr       error
+	DeleteLaunchConfigurationCallCount int
+	LaunchConfigurations               []*autoscaling.LaunchConfiguration
+}
+
+func (a *MockAutoScalingClient) CreateLaunchConfiguration(input *autoscaling.CreateLaunchConfigurationInput) (*autoscaling.CreateLaunchConfigurationOutput, error) {
+	return &autoscaling.CreateLaunchConfigurationOutput{}, a.CreateLaunchConfigurationErr
+}
+
+func (a *MockAutoScalingClient) DescribeLaunchConfigurationsPages(input *autoscaling.DescribeLaunchConfigurationsInput, callback func(*autoscaling.DescribeLaunchConfigurationsOutput, bool) bool) error {
+	page, err := a.DescribeLaunchConfigurations(input)
+	if err != nil {
+		return err
+	}
+	callback(page, false)
+	return nil
+}
+
+func (a *MockAutoScalingClient) DescribeLaunchConfigurations(input *autoscaling.DescribeLaunchConfigurationsInput) (*autoscaling.DescribeLaunchConfigurationsOutput, error) {
+	return &autoscaling.DescribeLaunchConfigurationsOutput{LaunchConfigurations: a.LaunchConfigurations}, a.DescribeLaunchConfigurationsErr
+}
+
+func (a *MockAutoScalingClient) DeleteLaunchConfiguration(input *autoscaling.DeleteLaunchConfigurationInput) (*autoscaling.DeleteLaunchConfigurationOutput, error) {
+	a.DeleteLaunchConfigurationCallCount++
+	return &autoscaling.DeleteLaunchConfigurationOutput{}, a.DeleteLaunchConfigurationErr
+}
+
+func TestDiscover(t *testing.T) {
+	var (
+		g       = gomega.NewGomegaWithT(t)
+		asgMock = &MockAutoScalingClient{}
+	)
+
+	w := awsprovider.AwsWorker{
+		AsgClient: asgMock,
+	}
+
+	discoveryInput := &DiscoverConfigurationInput{
+		ScalingGroup: &autoscaling.Group{
+			AutoScalingGroupName:    aws.String("my-asg"),
+			LaunchConfigurationName: aws.String("my-launch-config"),
+		},
+	}
+
+	targetResource := &autoscaling.LaunchConfiguration{
+		LaunchConfigurationName: aws.String("my-launch-config"),
+	}
+
+	resourceList := []*autoscaling.LaunchConfiguration{
+		targetResource,
+		{
+			LaunchConfigurationName: aws.String("other-launch-config"),
+		},
+	}
+
+	asgMock.LaunchConfigurations = resourceList
+	lc, err := NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.Equal(targetResource))
+	g.Expect(lc.ResourceList).To(gomega.Equal(resourceList))
+	g.Expect(lc.Provisioned()).To(gomega.BeTrue())
+	g.Expect(lc.Resource().(*autoscaling.LaunchConfiguration)).To(gomega.Equal(targetResource))
+	g.Expect(lc.Name()).To(gomega.Equal("my-launch-config"))
+
+	asgMock.LaunchConfigurations = []*autoscaling.LaunchConfiguration{}
+	lc, err = NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.BeNil())
+	g.Expect(lc.ResourceList).To(gomega.Equal([]*autoscaling.LaunchConfiguration{}))
+	g.Expect(lc.Provisioned()).To(gomega.BeFalse())
+	g.Expect(lc.Resource().(*autoscaling.LaunchConfiguration)).To(gomega.BeNil())
+	g.Expect(lc.Name()).To(gomega.BeEmpty())
+
+	asgMock.LaunchConfigurations = resourceList
+	asgMock.DescribeLaunchConfigurationsErr = errors.New("some-error")
+	lc, err = NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.BeNil())
+	g.Expect(lc.ResourceList).To(gomega.BeNil())
+	g.Expect(lc.Provisioned()).To(gomega.BeFalse())
+	g.Expect(lc.Resource().(*autoscaling.LaunchConfiguration)).To(gomega.BeNil())
+	g.Expect(lc.Name()).To(gomega.BeEmpty())
+	asgMock.DescribeLaunchConfigurationsErr = nil
+
+	discoveryInput.ScalingGroup.LaunchConfigurationName = aws.String("different-launch-configuration")
+	lc, err = NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.BeNil())
+	g.Expect(lc.ResourceList).To(gomega.Equal(resourceList))
+	g.Expect(lc.Provisioned()).To(gomega.BeFalse())
+	g.Expect(lc.Resource().(*autoscaling.LaunchConfiguration)).To(gomega.BeNil())
+	g.Expect(lc.Name()).To(gomega.BeEmpty())
+
+	discoveryInput.ScalingGroup = nil
+	lc, err = NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.BeNil())
+	g.Expect(lc.ResourceList).To(gomega.Equal(resourceList))
+	g.Expect(lc.Provisioned()).To(gomega.BeFalse())
+	g.Expect(lc.Resource().(*autoscaling.LaunchConfiguration)).To(gomega.BeNil())
+	g.Expect(lc.Name()).To(gomega.BeEmpty())
+}
+
+func TestCreate(t *testing.T) {
+	var (
+		g       = gomega.NewGomegaWithT(t)
+		asgMock = &MockAutoScalingClient{}
+	)
+
+	w := awsprovider.AwsWorker{
+		AsgClient: asgMock,
+	}
+
+	discoveryInput := &DiscoverConfigurationInput{
+		ScalingGroup: &autoscaling.Group{
+			AutoScalingGroupName:    aws.String("my-asg"),
+			LaunchConfigurationName: aws.String("my-launch-config"),
+		},
+	}
+
+	resourceList := []*autoscaling.LaunchConfiguration{
+		{
+			LaunchConfigurationName: aws.String("other-launch-config"),
+		},
+	}
+
+	asgMock.LaunchConfigurations = resourceList
+
+	lc, err := NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.BeNil())
+	g.Expect(lc.ResourceList).To(gomega.Equal(resourceList))
+
+	err = lc.Create(&CreateConfigurationInput{
+		Name:      "some-config",
+		SpotPrice: "1.0",
+		Volumes: []v1alpha1.NodeVolume{
+			{
+				Name: "/dev/xvda1",
+				Type: "gp2",
+				Size: 30,
+			},
+		},
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	resourceList = append(resourceList, &autoscaling.LaunchConfiguration{
+		LaunchConfigurationName: aws.String("my-launch-config"),
+	})
+	asgMock.LaunchConfigurations = resourceList
+
+	lc, err = NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.Equal(&autoscaling.LaunchConfiguration{
+		LaunchConfigurationName: aws.String("my-launch-config"),
+	}))
+	g.Expect(lc.ResourceList).To(gomega.Equal(resourceList))
+
+	err = lc.Create(&CreateConfigurationInput{
+		Name:      "some-config",
+		SpotPrice: "1.0",
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	asgMock.CreateLaunchConfigurationErr = errors.New("some-error")
+	err = lc.Create(&CreateConfigurationInput{
+		Name:      "some-config",
+		SpotPrice: "1.0",
+	})
+	g.Expect(err).To(gomega.HaveOccurred())
+	asgMock.CreateLaunchConfigurationErr = nil
+
+	discoveryInput.ScalingGroup = nil
+	lc, err = NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.BeNil())
+	g.Expect(lc.ResourceList).To(gomega.Equal(resourceList))
+	err = lc.Create(&CreateConfigurationInput{
+		Name:      "some-config",
+		SpotPrice: "1.0",
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func TestDelete(t *testing.T) {
+	var (
+		g       = gomega.NewGomegaWithT(t)
+		asgMock = &MockAutoScalingClient{}
+	)
+
+	w := awsprovider.AwsWorker{
+		AsgClient: asgMock,
+	}
+
+	discoveryInput := &DiscoverConfigurationInput{
+		ScalingGroup: &autoscaling.Group{
+			AutoScalingGroupName:    aws.String("my-asg"),
+			LaunchConfigurationName: aws.String("prefix-my-launch-config"),
+		},
+	}
+
+	now := time.Now()
+
+	resourceList := []*autoscaling.LaunchConfiguration{
+		{
+			LaunchConfigurationName: aws.String("prefix-my-launch-config"),
+			CreatedTime:             aws.Time(now.Add(time.Duration(-1) * time.Minute)),
+		},
+		{
+			LaunchConfigurationName: aws.String("diff-prefix-my-launch-config"),
+			CreatedTime:             aws.Time(now),
+		},
+		{
+			LaunchConfigurationName: aws.String("prefix-old-launch-config"),
+			CreatedTime:             aws.Time(now.Add(time.Duration(-2) * time.Minute)),
+		},
+		{
+			LaunchConfigurationName: aws.String("prefix-older-launch-config"),
+			CreatedTime:             aws.Time(now.Add(time.Duration(-3) * time.Minute)),
+		},
+		{
+			LaunchConfigurationName: aws.String("prefix-veryold-launch-config"),
+			CreatedTime:             aws.Time(now.Add(time.Duration(-4) * time.Minute)),
+		},
+	}
+
+	asgMock.LaunchConfigurations = resourceList
+
+	lc, err := NewLaunchConfiguration("", w, discoveryInput)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(lc.TargetResource).To(gomega.Equal(&autoscaling.LaunchConfiguration{
+		LaunchConfigurationName: aws.String("prefix-my-launch-config"),
+		CreatedTime:             aws.Time(now.Add(time.Duration(-1) * time.Minute)),
+	}))
+	g.Expect(lc.ResourceList).To(gomega.Equal(resourceList))
+
+	lc.Delete(&DeleteConfigurationInput{
+		Name:           "prefix-my-launch-config",
+		Prefix:         "prefix-",
+		RetainVersions: 2,
+		DeleteAll:      false,
+	})
+
+	g.Expect(asgMock.DeleteLaunchConfigurationCallCount).To(gomega.Equal(2))
+	asgMock.DeleteLaunchConfigurationCallCount = 0
+
+	lc.Delete(&DeleteConfigurationInput{
+		Name:           "prefix-my-launch-config",
+		Prefix:         "prefix-",
+		RetainVersions: 1,
+		DeleteAll:      false,
+	})
+
+	g.Expect(asgMock.DeleteLaunchConfigurationCallCount).To(gomega.Equal(3))
+	asgMock.DeleteLaunchConfigurationCallCount = 0
+
+	lc.Delete(&DeleteConfigurationInput{
+		Name:      "prefix-my-launch-config",
+		Prefix:    "prefix-",
+		DeleteAll: true,
+	})
+	g.Expect(asgMock.DeleteLaunchConfigurationCallCount).To(gomega.Equal(4))
+}
+
+func TestDrifted(t *testing.T) {
+	var (
+		g       = gomega.NewGomegaWithT(t)
+		asgMock = &MockAutoScalingClient{}
+	)
+
+	w := awsprovider.AwsWorker{
+		AsgClient: asgMock,
+	}
+
+	discoveryInput := &DiscoverConfigurationInput{
+		ScalingGroup: &autoscaling.Group{
+			AutoScalingGroupName:    aws.String("my-asg"),
+			LaunchConfigurationName: aws.String("my-launch-config"),
+		},
+	}
+
+	tests := []struct {
+		launchConfig *autoscaling.LaunchConfiguration
+		input        *CreateConfigurationInput
+		shouldDrift  bool
+	}{
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{},
+			},
+			shouldDrift: false,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("other-launch-config"),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{},
+			},
+			shouldDrift: true,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+				ImageId:                 aws.String("ami-12345678"),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{},
+				ImageId:        "ami-22222222",
+			},
+			shouldDrift: true,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+				InstanceType:            aws.String("m5.xlarge"),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{},
+				InstanceType:   "m5.2xlarge",
+			},
+			shouldDrift: true,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+				IamInstanceProfile:      aws.String("a-profile"),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups:        []string{},
+				IamInstanceProfileArn: "different-profile",
+			},
+			shouldDrift: true,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+				SecurityGroups:          aws.StringSlice([]string{"sg-1", "sg-2"}),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{"sg-1", "sg-3"},
+			},
+			shouldDrift: true,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+				SpotPrice:               aws.String("1.0"),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{},
+				SpotPrice:      "1.1",
+			},
+			shouldDrift: true,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+				UserData:                aws.String("userdata"),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{},
+				UserData:       "userdata2",
+			},
+			shouldDrift: true,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+				KeyName:                 aws.String("key"),
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{},
+				KeyName:        "key2",
+			},
+			shouldDrift: true,
+		},
+		{
+			launchConfig: &autoscaling.LaunchConfiguration{
+				LaunchConfigurationName: aws.String("my-launch-config"),
+				BlockDeviceMappings: []*autoscaling.BlockDeviceMapping{
+					{
+						DeviceName: aws.String("/dev/xvda"),
+						Ebs: &autoscaling.Ebs{
+							VolumeType: aws.String("gp2"),
+							VolumeSize: aws.Int64(32),
+						},
+					},
+				},
+			},
+			input: &CreateConfigurationInput{
+				SecurityGroups: []string{},
+				Volumes: []v1alpha1.NodeVolume{
+					{
+						Name: "/dev/xvda",
+						Type: "gp2",
+						Size: 32,
+					},
+				},
+			},
+			shouldDrift: true,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Logf("Test #%v", i)
+		asgMock.LaunchConfigurations = []*autoscaling.LaunchConfiguration{tc.launchConfig}
+		lc, err := NewLaunchConfiguration("", w, discoveryInput)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		result := lc.Drifted(tc.input)
+		g.Expect(result).To(gomega.Equal(tc.shouldDrift))
+	}
+}

--- a/controllers/provisioners/eks/state.go
+++ b/controllers/provisioners/eks/state.go
@@ -24,10 +24,6 @@ const (
 	ScalingGroupDeletionStatus = "Delete in progress"
 )
 
-var (
-	NonRetryableStates = []v1alpha1.ReconcileState{v1alpha1.ReconcileErr, v1alpha1.ReconcileReady, v1alpha1.ReconcileDeleted}
-)
-
 func (ctx *EksInstanceGroupContext) StateDiscovery() {
 	var (
 		instanceGroup = ctx.GetInstanceGroup()

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -17,7 +17,6 @@ package eks
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -26,12 +25,23 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	"github.com/keikoproj/instance-manager/controllers/common"
+	"github.com/keikoproj/instance-manager/controllers/provisioners/eks/scaling"
 )
 
 func (ctx *EksInstanceGroupContext) Update() error {
 	var (
-		instanceGroup  = ctx.GetInstanceGroup()
-		rotationNeeded bool
+		rotationNeeded        bool
+		instanceGroup         = ctx.GetInstanceGroup()
+		state                 = ctx.GetDiscoveredState()
+		scalingConfig         = state.GetScalingConfiguration()
+		configuration         = instanceGroup.GetEKSConfiguration()
+		instanceProfile       = state.GetInstanceProfile()
+		args                  = ctx.GetBootstrapArgs()
+		preScript, postScript = ctx.GetUserDataStages()
+		clusterName           = configuration.GetClusterName()
+		userData              = ctx.AwsWorker.GetBasicUserData(clusterName, args, preScript, postScript)
+		sgs                   = ctx.ResolveSecurityGroups()
+		spotPrice             = configuration.GetSpotPrice()
 	)
 
 	instanceGroup.SetState(v1alpha1.ReconcileModifying)
@@ -42,12 +52,25 @@ func (ctx *EksInstanceGroupContext) Update() error {
 		return errors.Wrap(err, "failed to update scaling group role")
 	}
 
+	config := &scaling.CreateConfigurationInput{
+		IamInstanceProfileArn: aws.StringValue(instanceProfile.Arn),
+		ImageId:               configuration.Image,
+		InstanceType:          configuration.InstanceType,
+		KeyName:               configuration.KeyPairName,
+		SecurityGroups:        sgs,
+		Volumes:               configuration.Volumes,
+		UserData:              userData,
+		SpotPrice:             spotPrice,
+	}
+
+	var configName string
+	configName = scalingConfig.Name()
 	// create new launchconfig if it has drifted
-	if ctx.LaunchConfigurationDrifted() {
+	if scalingConfig.Drifted(config) {
 		rotationNeeded = true
-		lcName := fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())
-		err := ctx.CreateLaunchConfiguration(lcName)
-		if err != nil {
+		configName = fmt.Sprintf("%v-%v", ctx.ResourcePrefix, common.GetTimeString())
+		config.Name = configName
+		if err := scalingConfig.Create(config); err != nil {
 			return errors.Wrap(err, "failed to create launch configuration")
 		}
 	}
@@ -57,7 +80,7 @@ func (ctx *EksInstanceGroupContext) Update() error {
 	}
 
 	// update scaling group
-	err = ctx.UpdateScalingGroup()
+	err = ctx.UpdateScalingGroup(configName)
 	if err != nil {
 		return errors.Wrap(err, "failed to update scaling group")
 	}
@@ -80,7 +103,7 @@ func (ctx *EksInstanceGroupContext) Update() error {
 	return nil
 }
 
-func (ctx *EksInstanceGroupContext) UpdateScalingGroup() error {
+func (ctx *EksInstanceGroupContext) UpdateScalingGroup(configName string) error {
 	var (
 		instanceGroup = ctx.GetInstanceGroup()
 		spec          = instanceGroup.GetEKSSpec()
@@ -92,10 +115,10 @@ func (ctx *EksInstanceGroupContext) UpdateScalingGroup() error {
 		rmTags        = ctx.GetRemovedTags(asgName)
 	)
 
-	if ctx.ScalingGroupUpdateNeeded() {
+	if ctx.ScalingGroupUpdateNeeded(configName) {
 		err := ctx.AwsWorker.UpdateScalingGroup(&autoscaling.UpdateAutoScalingGroupInput{
 			AutoScalingGroupName:    aws.String(asgName),
-			LaunchConfigurationName: aws.String(state.GetActiveLaunchConfigurationName()),
+			LaunchConfigurationName: aws.String(configName),
 			MinSize:                 aws.Int64(spec.GetMinSize()),
 			MaxSize:                 aws.Int64(spec.GetMaxSize()),
 			VPCZoneIdentifier:       aws.String(common.ConcatenateList(ctx.ResolveSubnets(), ",")),
@@ -107,6 +130,7 @@ func (ctx *EksInstanceGroupContext) UpdateScalingGroup() error {
 		ctx.Log.Info("updated scaling group", "instancegroup", instanceGroup.GetName(), "scalinggroup", asgName)
 	}
 
+	status.SetActiveLaunchConfigurationName(configName)
 	status.SetCurrentMin(int(spec.GetMinSize()))
 	status.SetCurrentMax(int(spec.GetMaxSize()))
 
@@ -133,6 +157,7 @@ func (ctx *EksInstanceGroupContext) RotationNeeded() bool {
 	var (
 		state         = ctx.GetDiscoveredState()
 		scalingGroup  = state.GetScalingGroup()
+		scalingConfig = state.GetScalingConfiguration()
 		instanceGroup = ctx.GetInstanceGroup()
 	)
 
@@ -140,9 +165,10 @@ func (ctx *EksInstanceGroupContext) RotationNeeded() bool {
 		return false
 	}
 
+	configName := scalingConfig.Name()
 	for _, instance := range scalingGroup.Instances {
-		if aws.StringValue(instance.LaunchConfigurationName) != state.GetActiveLaunchConfigurationName() {
-			ctx.Log.Info("rotation needed due to launch-config diff", "instancegroup", instanceGroup.GetName(), "launchconfig", state.GetActiveLaunchConfigurationName())
+		if aws.StringValue(instance.LaunchConfigurationName) != configName {
+			ctx.Log.Info("rotation needed due to launch-config diff", "instancegroup", instanceGroup.GetName(), "launchconfig", configName)
 			return true
 		}
 	}
@@ -181,7 +207,7 @@ func (ctx *EksInstanceGroupContext) TagsUpdateNeeded() bool {
 	return false
 }
 
-func (ctx *EksInstanceGroupContext) ScalingGroupUpdateNeeded() bool {
+func (ctx *EksInstanceGroupContext) ScalingGroupUpdateNeeded(configName string) bool {
 	var (
 		instanceGroup  = ctx.GetInstanceGroup()
 		spec           = instanceGroup.GetEKSSpec()
@@ -192,7 +218,7 @@ func (ctx *EksInstanceGroupContext) ScalingGroupUpdateNeeded() bool {
 		specSubnets    = ctx.ResolveSubnets()
 	)
 
-	if state.GetActiveLaunchConfigurationName() != aws.StringValue(scalingGroup.LaunchConfigurationName) {
+	if configName != aws.StringValue(scalingGroup.LaunchConfigurationName) {
 		return true
 	}
 
@@ -209,120 +235,6 @@ func (ctx *EksInstanceGroupContext) ScalingGroupUpdateNeeded() bool {
 	}
 
 	return false
-}
-
-func (ctx *EksInstanceGroupContext) LaunchConfigurationDrifted() bool {
-	var (
-		state         = ctx.GetDiscoveredState()
-		instanceGroup = ctx.GetInstanceGroup()
-		// only used for comparison, no need to generate a name
-		newConfig      = ctx.GetLaunchConfigurationInput("")
-		existingConfig = state.GetLaunchConfiguration()
-		drift          bool
-	)
-
-	if state.LaunchConfiguration == nil {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "launchconfig does not exist",
-			"instancegroup", instanceGroup.GetName(),
-		)
-		return true
-	}
-
-	if aws.StringValue(existingConfig.ImageId) != aws.StringValue(newConfig.ImageId) {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "image-id has changed",
-			"instancegroup", instanceGroup.GetName(),
-			"previousValue", aws.StringValue(existingConfig.ImageId),
-			"newValue", aws.StringValue(newConfig.ImageId),
-		)
-		drift = true
-	}
-
-	if aws.StringValue(existingConfig.InstanceType) != aws.StringValue(newConfig.InstanceType) {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "instance-type has changed",
-			"instancegroup", instanceGroup.GetName(),
-			"previousValue", aws.StringValue(existingConfig.InstanceType),
-			"newValue", aws.StringValue(newConfig.InstanceType),
-		)
-		drift = true
-	}
-
-	if aws.StringValue(existingConfig.IamInstanceProfile) != aws.StringValue(newConfig.IamInstanceProfile) {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "instance-profile has changed",
-			"instancegroup", instanceGroup.GetName(),
-			"previousValue", aws.StringValue(existingConfig.IamInstanceProfile),
-			"newValue", aws.StringValue(newConfig.IamInstanceProfile),
-		)
-		drift = true
-	}
-
-	if !common.StringSliceEquals(aws.StringValueSlice(existingConfig.SecurityGroups), aws.StringValueSlice(newConfig.SecurityGroups)) {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "security-groups has changed",
-			"instancegroup", instanceGroup.GetName(),
-			"previousValue", aws.StringValueSlice(existingConfig.SecurityGroups),
-			"newValue", aws.StringValueSlice(newConfig.SecurityGroups),
-		)
-		drift = true
-	}
-
-	if aws.StringValue(existingConfig.SpotPrice) != aws.StringValue(newConfig.SpotPrice) {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "spot-price has changed",
-			"instancegroup", instanceGroup.GetName(),
-			"previousValue", aws.StringValue(existingConfig.SpotPrice),
-			"newValue", aws.StringValue(newConfig.SpotPrice),
-		)
-		drift = true
-	}
-
-	if aws.StringValue(existingConfig.KeyName) != aws.StringValue(newConfig.KeyName) {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "key-pair-name has changed",
-			"instancegroup", instanceGroup.GetName(),
-			"previousValue", aws.StringValue(existingConfig.KeyName),
-			"newValue", aws.StringValue(newConfig.KeyName),
-		)
-		drift = true
-	}
-
-	if aws.StringValue(existingConfig.UserData) != aws.StringValue(newConfig.UserData) {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "user-data has changed",
-			"instancegroup", instanceGroup.GetName(),
-			"previousValue", aws.StringValue(existingConfig.UserData),
-			"newValue", aws.StringValue(newConfig.UserData),
-		)
-		drift = true
-	}
-
-	if !reflect.DeepEqual(existingConfig.BlockDeviceMappings, newConfig.BlockDeviceMappings) {
-		ctx.Log.Info(
-			"detected drift",
-			"reason", "volumes have changed",
-			"instancegroup", instanceGroup.GetName(),
-			"previousValue", existingConfig.BlockDeviceMappings,
-			"newValue", newConfig.BlockDeviceMappings,
-		)
-		drift = true
-	}
-
-	if !drift {
-		ctx.Log.Info("no drift detected", "instancegroup", instanceGroup.GetName())
-	}
-
-	return drift
 }
 
 func (ctx *EksInstanceGroupContext) UpdateManagedPolicies(roleName string) error {

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -35,7 +35,6 @@ func (ctx *EksInstanceGroupContext) Update() error {
 		state                 = ctx.GetDiscoveredState()
 		scalingConfig         = state.GetScalingConfiguration()
 		configuration         = instanceGroup.GetEKSConfiguration()
-		instanceProfile       = state.GetInstanceProfile()
 		args                  = ctx.GetBootstrapArgs()
 		preScript, postScript = ctx.GetUserDataStages()
 		clusterName           = configuration.GetClusterName()
@@ -51,6 +50,7 @@ func (ctx *EksInstanceGroupContext) Update() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to update scaling group role")
 	}
+	instanceProfile := state.GetInstanceProfile()
 
 	config := &scaling.CreateConfigurationInput{
 		IamInstanceProfileArn: aws.StringValue(instanceProfile.Arn),

--- a/controllers/provisioners/eks/update_test.go
+++ b/controllers/provisioners/eks/update_test.go
@@ -469,6 +469,8 @@ func TestUpdateManagedPolicies(t *testing.T) {
 		{attachedPolicies: MockAttachedPolicies(), additionalPolicies: []string{}, expectedAttached: 3, expectedDetached: 0},
 		// additional policies need to be attached
 		{attachedPolicies: MockAttachedPolicies(DefaultManagedPolicies...), additionalPolicies: []string{"policy-1", "policy-2"}, expectedAttached: 2, expectedDetached: 0},
+		// additional policies with ARN
+		{attachedPolicies: MockAttachedPolicies(DefaultManagedPolicies...), additionalPolicies: []string{"arn:aws:iam::aws:policy/policy-1", "arn:aws:iam::12345679012:policy/policy-2"}, expectedAttached: 2, expectedDetached: 0},
 		// additional policies need to be detached
 		{attachedPolicies: MockAttachedPolicies("AmazonEKSWorkerNodePolicy", "AmazonEKS_CNI_Policy", "AmazonEC2ContainerRegistryReadOnly", "policy-1"), additionalPolicies: []string{}, expectedAttached: 0, expectedDetached: 1},
 		// additional policies need to be attached & detached

--- a/controllers/provisioners/eks/update_test.go
+++ b/controllers/provisioners/eks/update_test.go
@@ -34,13 +34,14 @@ import (
 
 func TestUpdateWithDriftRotationPositive(t *testing.T) {
 	var (
-		g       = gomega.NewGomegaWithT(t)
-		k       = MockKubernetesClientSet()
-		ig      = MockInstanceGroup()
-		asgMock = NewAutoScalingMocker()
-		iamMock = NewIamMocker()
-		eksMock = NewEksMocker()
-		ec2Mock = NewEc2Mocker()
+		g             = gomega.NewGomegaWithT(t)
+		k             = MockKubernetesClientSet()
+		ig            = MockInstanceGroup()
+		configuration = ig.GetEKSConfiguration()
+		asgMock       = NewAutoScalingMocker()
+		iamMock       = NewIamMocker()
+		eksMock       = NewEksMocker()
+		ec2Mock       = NewEc2Mocker()
 	)
 
 	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
@@ -64,6 +65,16 @@ func TestUpdateWithDriftRotationPositive(t *testing.T) {
 	}
 	asgMock.AutoScalingGroups = []*autoscaling.Group{mockScalingGroup}
 
+	configuration.Tags = []map[string]string{
+		{
+			"key":   "some-tag",
+			"value": "some-value",
+		},
+		{
+			"key":   "other-tag",
+			"value": "other-value",
+		},
+	}
 	// create matching node object
 	mockNode := &corev1.Node{
 		Spec: corev1.NodeSpec{

--- a/controllers/provisioners/eksfargate/eksfargate.go
+++ b/controllers/provisioners/eksfargate/eksfargate.go
@@ -39,10 +39,6 @@ const (
 	PendingRoleCreation     = "pendingRoleCreation"
 )
 
-var (
-	NonRetryableStates = []v1alpha1.ReconcileState{v1alpha1.ReconcileErr, v1alpha1.ReconcileReady, v1alpha1.ReconcileDeleted}
-)
-
 const (
 	OngoingStateString             = "OngoingState"
 	FiniteStateString              = "FiniteState"
@@ -133,14 +129,7 @@ func CreateFargateTags(tagArray []map[string]string) map[string]*string {
 	}
 	return tags
 }
-func IsRetryable(instanceGroup *v1alpha1.InstanceGroup) bool {
-	for _, state := range NonRetryableStates {
-		if state == instanceGroup.GetState() {
-			return false
-		}
-	}
-	return true
-}
+
 func (ctx *FargateInstanceGroupContext) Create() error {
 	var arn string
 	instanceGroup := ctx.GetInstanceGroup()

--- a/controllers/provisioners/eksfargate/eksfargate_test.go
+++ b/controllers/provisioners/eksfargate/eksfargate_test.go
@@ -892,46 +892,6 @@ func TestDeleteWithRetry(t *testing.T) {
 		t.Fatalf("TestDeleteWithRetry: expected nil.  Got %v", err)
 	}
 }
-func TestIsRetryableFalse1(t *testing.T) {
-	ig := FakeIG{}
-	instanceGroup := ig.getInstanceGroup()
-	instanceGroup.SetState(v1alpha1.ReconcileDeleted)
-	retryable := IsRetryable(instanceGroup)
-	if retryable {
-		t.Fatal("TestIsRetryableFalse1: expected false.")
-	}
-
-}
-func TestIsRetryableFalse2(t *testing.T) {
-	ig := FakeIG{}
-	instanceGroup := ig.getInstanceGroup()
-	instanceGroup.SetState(v1alpha1.ReconcileReady)
-	retryable := IsRetryable(instanceGroup)
-	if retryable {
-		t.Fatal("TestIsRetryableFalse2: expected false.")
-	}
-
-}
-func TestIsRetryableFalse3(t *testing.T) {
-	ig := FakeIG{}
-	instanceGroup := ig.getInstanceGroup()
-	instanceGroup.SetState(v1alpha1.ReconcileErr)
-	retryable := IsRetryable(instanceGroup)
-	if retryable {
-		t.Fatal("TestIsRetryableFalse3: expected false.")
-	}
-
-}
-func TestIsRetryableTrue(t *testing.T) {
-	ig := FakeIG{}
-	instanceGroup := ig.getInstanceGroup()
-	instanceGroup.SetState(v1alpha1.ReconcileModifying)
-	retryable := IsRetryable(instanceGroup)
-	if !retryable {
-		t.Fatal("TestIsRetryableTrue: expected true.")
-	}
-
-}
 func TestCreateProfileName(t *testing.T) {
 	ig := FakeIG{}
 	instanceGroup := ig.getInstanceGroup()

--- a/controllers/provisioners/eksmanaged/eksmanaged.go
+++ b/controllers/provisioners/eksmanaged/eksmanaged.go
@@ -33,10 +33,6 @@ const (
 	ProvisionerName                = "eks-managed"
 )
 
-var (
-	NonRetryableStates = []v1alpha1.ReconcileState{v1alpha1.ReconcileErr, v1alpha1.ReconcileReady, v1alpha1.ReconcileDeleted}
-)
-
 func (ctx *EksManagedInstanceGroupContext) CloudDiscovery() error {
 	var (
 		provisioned     = ctx.AwsWorker.IsNodeGroupExist()
@@ -262,13 +258,4 @@ func (ctx *EksManagedInstanceGroupContext) processParameters() {
 	params["MinSize"] = spec.GetMinSize()
 	params["MaxSize"] = spec.GetMaxSize()
 	ctx.AwsWorker.Parameters = params
-}
-
-func IsRetryable(instanceGroup *v1alpha1.InstanceGroup) bool {
-	for _, state := range NonRetryableStates {
-		if state == instanceGroup.GetState() {
-			return false
-		}
-	}
-	return true
 }

--- a/controllers/provisioners/provisioners.go
+++ b/controllers/provisioners/provisioners.go
@@ -29,3 +29,16 @@ type ProvisionerInput struct {
 	Configuration *corev1.ConfigMap
 	Log           logr.Logger
 }
+
+var (
+	NonRetryableStates = []v1alpha1.ReconcileState{v1alpha1.ReconcileErr, v1alpha1.ReconcileReady, v1alpha1.ReconcileDeleted}
+)
+
+func IsRetryable(instanceGroup *v1alpha1.InstanceGroup) bool {
+	for _, state := range NonRetryableStates {
+		if state == instanceGroup.GetState() {
+			return false
+		}
+	}
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ func main() {
 			setupLog.Error(err, "could not get instance-manager configmap")
 			os.Exit(1)
 		}
-		cm = nil
+		cm = &corev1.ConfigMap{}
 		setupLog.Info("instance-manager configmap does not exist, will not load defaults/boundaries")
 	}
 

--- a/main.go
+++ b/main.go
@@ -124,12 +124,14 @@ func main() {
 		KubeDynamic: dynClient,
 	}
 
-	cm, err := client.CoreV1().ConfigMaps(configNamespace).Get(controllers.ConfigMapName, metav1.GetOptions{})
+	var cm *corev1.ConfigMap
+	cm, err = client.CoreV1().ConfigMaps(configNamespace).Get(controllers.ConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if !kerrors.IsNotFound(err) {
 			setupLog.Error(err, "could not get instance-manager configmap")
 			os.Exit(1)
 		}
+		cm = nil
 		setupLog.Info("instance-manager configmap does not exist, will not load defaults/boundaries")
 	}
 


### PR DESCRIPTION
Ref #17 
Fixes #163 

This abstracts the concrete launch configuration state/provisioner into an interface called ScalingConfiguration which can create multiple types of configurations.

Added the implementation of a LaunchConfiguration type and refactored the code & tests to use that instead of existing implementation.

This will allow to create a new ScalingConfiguration type later called LaunchTemplate

- [x] BDD passing
- [x] Manual testing