### PR TITLE
add strategy & provisioner to status

### DIFF
--- a/api/v1alpha1/instancegroup_types.go
+++ b/api/v1alpha1/instancegroup_types.go
@@ -100,8 +100,8 @@ var (
 // +kubebuilder:printcolumn:name="Min",type="integer",JSONPath=".status.currentMin",description="currently set min instancegroup size"
 // +kubebuilder:printcolumn:name="Max",type="integer",JSONPath=".status.currentMax",description="currently set max instancegroup size"
 // +kubebuilder:printcolumn:name="Group Name",type="string",JSONPath=".status.activeScalingGroupName",description="instancegroup created scalinggroup name"
-// +kubebuilder:printcolumn:name="Provisioner",type="string",JSONPath=".spec.provisioner",description="instance group provisioner"
-// +kubebuilder:printcolumn:name="Strategy",type="string",JSONPath=".spec.strategy.type",description="instance group upgrade strategy"
+// +kubebuilder:printcolumn:name="Provisioner",type="string",JSONPath=".status.provisioner",description="instance group provisioner"
+// +kubebuilder:printcolumn:name="Strategy",type="string",JSONPath=".status.strategy",description="instance group upgrade strategy"
 // +kubebuilder:printcolumn:name="Lifecycle",type="string",JSONPath=".status.lifecycle",description="instance group lifecycle spot/normal"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="time passed since instancegroup creation"
 type InstanceGroup struct {
@@ -254,6 +254,8 @@ type InstanceGroupStatus struct {
 	Lifecycle                     string                   `json:"lifecycle,omitempty"`
 	ConfigHash                    string                   `json:"configMD5,omitempty"`
 	Conditions                    []InstanceGroupCondition `json:"conditions,omitempty"`
+	Provisioner                   string                   `json:"provisioner,omitempty"`
+	Strategy                      string                   `json:"strategy,omitempty"`
 }
 
 type InstanceGroupConditionType string
@@ -660,6 +662,14 @@ func (status *InstanceGroupStatus) GetActiveScalingGroupName() string {
 
 func (status *InstanceGroupStatus) SetActiveScalingGroupName(name string) {
 	status.ActiveScalingGroupName = name
+}
+
+func (status *InstanceGroupStatus) SetStrategy(strategy string) {
+	status.Strategy = strategy
+}
+
+func (status *InstanceGroupStatus) SetProvisioner(provisioner string) {
+	status.Provisioner = provisioner
 }
 
 func (status *InstanceGroupStatus) GetNodesArn() string {

--- a/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
+++ b/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
@@ -25,11 +25,11 @@ spec:
     description: instancegroup created scalinggroup name
     name: Group Name
     type: string
-  - JSONPath: .spec.provisioner
+  - JSONPath: .status.provisioner
     description: instance group provisioner
     name: Provisioner
     type: string
-  - JSONPath: .spec.strategy.type
+  - JSONPath: .status.strategy
     description: instance group upgrade strategy
     name: Strategy
     type: string
@@ -353,6 +353,10 @@ spec:
             lifecycle:
               type: string
             nodesInstanceRoleArn:
+              type: string
+            provisioner:
+              type: string
+            strategy:
               type: string
             strategyResourceName:
               type: string

--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -47,6 +47,7 @@ func New(p provisioners.ProvisionerInput) *EksInstanceGroupContext {
 		instanceGroup = p.InstanceGroup
 		configuration = instanceGroup.GetEKSConfiguration()
 		status        = instanceGroup.GetStatus()
+		strategy      = instanceGroup.GetUpgradeStrategy()
 		configHash    = kubeprovider.ConfigmapHash(p.Configuration)
 	)
 
@@ -60,6 +61,8 @@ func New(p provisioners.ProvisionerInput) *EksInstanceGroupContext {
 
 	instanceGroup.SetState(v1alpha1.ReconcileInit)
 	status.SetConfigHash(configHash)
+	status.SetProvisioner(ProvisionerName)
+	status.SetStrategy(strategy.Type)
 
 	return ctx
 }


### PR DESCRIPTION
Fixes #170 

Adds strategy & provisioner as status fields so that it's never missing in printer columns when using configmap defaults