### PR TITLE
make config retention configurable

### DIFF
--- a/controllers/instancegroup_controller.go
+++ b/controllers/instancegroup_controller.go
@@ -47,6 +47,7 @@ type InstanceGroupReconciler struct {
 	MaxParallel            int
 	Auth                   *InstanceGroupAuthenticator
 	ConfigMap              *corev1.ConfigMap
+	ConfigRetention        int
 }
 
 type InstanceGroupAuthenticator struct {
@@ -114,11 +115,12 @@ func (r *InstanceGroupReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	r.SetFinalizer(instanceGroup)
 
 	input := provisioners.ProvisionerInput{
-		AwsWorker:     r.Auth.Aws,
-		Kubernetes:    r.Auth.Kubernetes,
-		Configuration: r.ConfigMap,
-		InstanceGroup: instanceGroup,
-		Log:           r.Log,
+		AwsWorker:       r.Auth.Aws,
+		Kubernetes:      r.Auth.Kubernetes,
+		Configuration:   r.ConfigMap,
+		InstanceGroup:   instanceGroup,
+		Log:             r.Log,
+		ConfigRetention: r.ConfigRetention,
 	}
 
 	if !reflect.DeepEqual(r.ConfigMap, &corev1.ConfigMap{}) {

--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -145,9 +145,10 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 
 	// delete old launch configurations
 	state.ScalingConfiguration.Delete(&scaling.DeleteConfigurationInput{
-		Name:      configName,
-		Prefix:    ctx.ResourcePrefix,
-		DeleteAll: false,
+		Name:           configName,
+		Prefix:         ctx.ResourcePrefix,
+		DeleteAll:      false,
+		RetainVersions: ctx.ConfigRetention,
 	})
 
 	if status.GetNodesReadyCondition() == corev1.ConditionTrue {

--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -56,6 +56,7 @@ func New(p provisioners.ProvisionerInput) *EksInstanceGroupContext {
 		AwsWorker:        p.AwsWorker,
 		Log:              p.Log.WithName("eks"),
 		ResourcePrefix:   fmt.Sprintf("%v-%v-%v", configuration.GetClusterName(), instanceGroup.GetNamespace(), instanceGroup.GetName()),
+		ConfigRetention:  p.ConfigRetention,
 	}
 
 	instanceGroup.SetState(v1alpha1.ReconcileInit)
@@ -72,6 +73,7 @@ type EksInstanceGroupContext struct {
 	DiscoveredState  *DiscoveredState
 	Log              logr.Logger
 	Configuration    *provisioners.ProvisionerConfiguration
+	ConfigRetention  int
 	ResourcePrefix   string
 }
 

--- a/controllers/provisioners/provisioners.go
+++ b/controllers/provisioners/provisioners.go
@@ -23,11 +23,12 @@ const (
 )
 
 type ProvisionerInput struct {
-	AwsWorker     awsprovider.AwsWorker
-	Kubernetes    kubeprovider.KubernetesClientSet
-	InstanceGroup *v1alpha1.InstanceGroup
-	Configuration *corev1.ConfigMap
-	Log           logr.Logger
+	AwsWorker       awsprovider.AwsWorker
+	Kubernetes      kubeprovider.KubernetesClientSet
+	InstanceGroup   *v1alpha1.InstanceGroup
+	Configuration   *corev1.ConfigMap
+	Log             logr.Logger
+	ConfigRetention int
 }
 
 var (

--- a/main.go
+++ b/main.go
@@ -68,11 +68,13 @@ func main() {
 		nodeRelabel            bool
 		maxParallel            int
 		maxAPIRetries          int
+		configRetention        int
 		err                    error
 	)
 
 	flag.IntVar(&maxParallel, "max-workers", 5, "The number of maximum parallel reconciles")
 	flag.IntVar(&maxAPIRetries, "max-api-retries", 12, "The number of maximum retries for failed AWS API calls")
+	flag.IntVar(&configRetention, "config-retention", 2, "The number of launch configuration/template versions to retain")
 	flag.Float64Var(&spotRecommendationTime, "spot-recommendation-time", 10.0, "The maximum age of spot recommendation events to consider in minutes")
 	flag.StringVar(&configNamespace, "config-namespace", "instance-manager", "the namespace to watch for instance-manager configmap")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
@@ -137,6 +139,7 @@ func main() {
 
 	err = (&controllers.InstanceGroupReconciler{
 		ConfigMap:              cm,
+		ConfigRetention:        configRetention,
 		SpotRecommendationTime: spotRecommendationTime,
 		ConfigNamespace:        configNamespace,
 		NodeRelabel:            nodeRelabel,


### PR DESCRIPTION
closes #116 

This takes a new flag `--config-retention` that determines how many launch configurations we retain - defaults to 2.