### PR TITLE
feat: Add BottleRocket os family

### DIFF
--- a/controllers/provisioners/eks/create_test.go
+++ b/controllers/provisioners/eks/create_test.go
@@ -46,7 +46,13 @@ func TestCreateManagedRolePositive(t *testing.T) {
 	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 	state := ctx.GetDiscoveredState()
-	state.SetCluster(&eks.Cluster{Version: aws.String("1.15")})
+	state.SetCluster(&eks.Cluster{
+		Version: aws.String("1.15"),
+		CertificateAuthority: &eks.Certificate{
+			Data: aws.String("clusterca"),
+		},
+		Endpoint: aws.String("foo.amazonaws.com"),
+	})
 	state.Publisher.Client = k.Kubernetes
 	state.ScalingConfiguration = &scaling.LaunchConfiguration{
 		AwsWorker: w,
@@ -136,6 +142,12 @@ func TestCreateScalingGroupPositive(t *testing.T) {
 		Publisher: kubeprovider.EventPublisher{
 			Client: k.Kubernetes,
 		},
+		Cluster: &eks.Cluster{
+			CertificateAuthority: &eks.Certificate{
+				Data: aws.String("foo"),
+			},
+			Endpoint: aws.String("foo.amazonaws.com"),
+		},
 		ScalingConfiguration: lc,
 	})
 
@@ -175,6 +187,13 @@ func TestCreateNoOp(t *testing.T) {
 	}
 
 	ctx.SetDiscoveredState(&DiscoveredState{
+		Cluster: &eks.Cluster{
+			CertificateAuthority: &eks.Certificate{
+				Data: aws.String(""),
+			},
+			Endpoint:           aws.String("foo.amazonaws.com"),
+			ResourcesVpcConfig: &eks.VpcConfigResponse{},
+		},
 		Publisher: kubeprovider.EventPublisher{
 			Client: k.Kubernetes,
 		},

--- a/controllers/provisioners/eks/create_test.go
+++ b/controllers/provisioners/eks/create_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	"github.com/onsi/gomega"
@@ -46,13 +45,7 @@ func TestCreateManagedRolePositive(t *testing.T) {
 	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
 	state := ctx.GetDiscoveredState()
-	state.SetCluster(&eks.Cluster{
-		Version: aws.String("1.15"),
-		CertificateAuthority: &eks.Certificate{
-			Data: aws.String("clusterca"),
-		},
-		Endpoint: aws.String("foo.amazonaws.com"),
-	})
+	state.SetCluster(MockEksCluster("1.15"))
 	state.Publisher.Client = k.Kubernetes
 	state.ScalingConfiguration = &scaling.LaunchConfiguration{
 		AwsWorker: w,
@@ -142,12 +135,7 @@ func TestCreateScalingGroupPositive(t *testing.T) {
 		Publisher: kubeprovider.EventPublisher{
 			Client: k.Kubernetes,
 		},
-		Cluster: &eks.Cluster{
-			CertificateAuthority: &eks.Certificate{
-				Data: aws.String("foo"),
-			},
-			Endpoint: aws.String("foo.amazonaws.com"),
-		},
+		Cluster:              MockEksCluster(""),
 		ScalingConfiguration: lc,
 	})
 
@@ -187,13 +175,7 @@ func TestCreateNoOp(t *testing.T) {
 	}
 
 	ctx.SetDiscoveredState(&DiscoveredState{
-		Cluster: &eks.Cluster{
-			CertificateAuthority: &eks.Certificate{
-				Data: aws.String(""),
-			},
-			Endpoint:           aws.String("foo.amazonaws.com"),
-			ResourcesVpcConfig: &eks.VpcConfigResponse{},
-		},
+		Cluster: MockEksCluster(""),
 		Publisher: kubeprovider.EventPublisher{
 			Client: k.Kubernetes,
 		},

--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -130,8 +130,7 @@ func (ctx *EksInstanceGroupContext) GetOsFamily() string {
 	if _, exists := annotations[OsFamilyAnnotation]; exists {
 		return annotations[OsFamilyAnnotation]
 	}
-	return OsFamilyAmazonLinux2 // return "" is will also be fine here
-
+	return OsFamilyAmazonLinux2
 }
 
 func (ctx *EksInstanceGroupContext) GetUpgradeStrategy() *v1alpha1.AwsUpgradeStrategy {

--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -37,6 +37,7 @@ const (
 
 	OsFamilyWindows      = "windows"
 	OsFamilyBottleRocket = "bottlerocket"
+	OsFamilyAmazonLinux2 = "amazonlinux2"
 )
 
 var (
@@ -129,7 +130,7 @@ func (ctx *EksInstanceGroupContext) GetOsFamily() string {
 	if _, exists := annotations[OsFamilyAnnotation]; exists {
 		return annotations[OsFamilyAnnotation]
 	}
-	return "default" // return "" is will also be fine here
+	return OsFamilyAmazonLinux2 // return "" is will also be fine here
 
 }
 

--- a/controllers/provisioners/eks/eks_test.go
+++ b/controllers/provisioners/eks/eks_test.go
@@ -64,13 +64,7 @@ func NewIamMocker() *MockIamClient {
 
 func NewEksMocker() *MockEksClient {
 	mock := &MockEksClient{
-		EksCluster: &eks.Cluster{
-			CertificateAuthority: &eks.Certificate{
-				Data: aws.String(""),
-			},
-			Endpoint:           aws.String("foo.amazonaws.com"),
-			ResourcesVpcConfig: &eks.VpcConfigResponse{},
-		},
+		EksCluster: MockEksCluster("1.18"),
 	}
 	return mock
 }
@@ -88,6 +82,17 @@ func MockAwsWorker(asgClient *MockAutoScalingClient, iamClient *MockIamClient, e
 	}
 }
 
+func MockEksCluster(version string) *eks.Cluster {
+	return &eks.Cluster{
+		CertificateAuthority: &eks.Certificate{
+			Data: aws.String(""),
+		},
+		Endpoint:           aws.String("foo.amazonaws.com"),
+		ResourcesVpcConfig: &eks.VpcConfigResponse{},
+		Version:            &version,
+	}
+}
+
 func MockKubernetesClientSet() kubeprovider.KubernetesClientSet {
 	return kubeprovider.KubernetesClientSet{
 		Kubernetes:  fake.NewSimpleClientset(),
@@ -96,10 +101,6 @@ func MockKubernetesClientSet() kubeprovider.KubernetesClientSet {
 }
 
 func MockContext(instanceGroup *v1alpha1.InstanceGroup, kube kubeprovider.KubernetesClientSet, w awsprovider.AwsWorker) *EksInstanceGroupContext {
-	var (
-		clusterCa       = "somestring"
-		clusterEndpoint = "foo.amazonaws.com"
-	)
 	input := provisioners.ProvisionerInput{
 		AwsWorker:     w,
 		Kubernetes:    kube,
@@ -109,24 +110,9 @@ func MockContext(instanceGroup *v1alpha1.InstanceGroup, kube kubeprovider.Kubern
 	context := New(input)
 
 	context.DiscoveredState = &DiscoveredState{
-		Provisioned:          false,
-		NodesReady:           false,
-		ClusterNodes:         nil,
-		OwnedScalingGroups:   nil,
-		ScalingGroup:         nil,
-		LifecycleHooks:       nil,
-		ScalingConfiguration: nil,
-		IAMRole:              nil,
-		AttachedPolicies:     nil,
-		InstanceProfile:      nil,
-		Publisher:            kubeprovider.EventPublisher{},
-		Cluster: &eks.Cluster{
-			Endpoint: &clusterEndpoint,
-			CertificateAuthority: &eks.Certificate{
-				Data: &clusterCa,
-			},
-		},
-		VPCId: "",
+		Publisher: kubeprovider.EventPublisher{},
+		Cluster:   MockEksCluster("1.18"),
+		VPCId:     "",
 	}
 	return context
 }

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -249,7 +249,7 @@ func (ctx *EksInstanceGroupContext) GetAddedTags(asgName string) []*autoscaling.
 		configuration = instanceGroup.GetEKSConfiguration()
 		clusterName   = configuration.GetClusterName()
 		annotations   = instanceGroup.GetAnnotations()
-		labels        = configuration.GetLabels()
+		labels        = ctx.GetComputedLabels()
 		taints        = configuration.GetTaints()
 	)
 

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -133,7 +133,7 @@ cluster-name = "{{ .ClusterName }}"
 "{{ .Key }}" = "{{ .Value }}:{{ .Effect }}"
 {{- end}}
 `
-	default:
+	case OsFamilyAmazonLinux2:
 		UserDataTemplate = `#!/bin/bash
 {{range $pre := .PreBootstrap}}{{$pre}}{{end}}
 {{- range .MountOptions}}

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -97,18 +97,43 @@ func (ctx *EksInstanceGroupContext) ResolveSecurityGroups() []string {
 }
 
 func (ctx *EksInstanceGroupContext) GetBasicUserData(clusterName, args string, kubeletExtraArgs string, payload UserDataPayload, mounts []MountOpts) string {
-      osFamily := ctx.GetOsFamily()
+	var (
+		instanceGroup = ctx.GetInstanceGroup()
+		configuration = instanceGroup.GetEKSConfiguration()
+		cluster       = ctx.GetDiscoveredState().Cluster
+		apiEndpoint   = cluster.Endpoint
+		clusterCa     = cluster.CertificateAuthority.Data
+		osFamily      = ctx.GetOsFamily()
+		nodeLabels    = ctx.GetComputedLabels()
+		nodeTaints    = configuration.GetTaints()
+	)
+
 	var UserDataTemplate string
-	if strings.EqualFold(osFamily, OsFamilyWindows) {
+	switch strings.ToLower(osFamily) {
+	case OsFamilyWindows:
 		UserDataTemplate = `
 <powershell>
   [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
   [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
   [string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
   & $EKSBootstrapScriptFile -EKSClusterName {{ .ClusterName }} -KubeletExtraArgs '{{ .KubeletExtraArgs }}' 3>&1 4>&1 5>&1 6>&1
-</powershell>
-		`
-	} else {
+</powershell>`
+	case OsFamilyBottleRocket:
+		UserDataTemplate = `
+[settings.kubernetes]
+api-server   = "{{ .ApiEndpoint }}"
+cluster-certificate = "{{ .ClusterCA }}"
+cluster-name = "{{ .ClusterName }}"
+[settings.kubernetes.node-labels]
+{{- range $key, $value := .NodeLabels }}
+"{{ $key }}" = "{{ $value }}"
+{{- end}}
+[settings.kubernetes.node-taints]
+{{- range .NodeTaints}}
+"{{ .Key }}" = "{{ .Value }}:{{ .Effect }}"
+{{- end}}
+`
+	default:
 		UserDataTemplate = `#!/bin/bash
 {{range $pre := .PreBootstrap}}{{$pre}}{{end}}
 {{- range .MountOptions}}
@@ -125,13 +150,18 @@ set -o xtrace
 set +o xtrace
 {{range $post := .PostBootstrap}}{{$post}}{{end}}`
 	}
+
 	data := EKSUserData{
-		ClusterName:   clusterName,
+		ApiEndpoint:      *apiEndpoint,
+		ClusterCA:        *clusterCa,
+		ClusterName:      clusterName,
+		NodeLabels:       nodeLabels,
+		NodeTaints:       nodeTaints,
 		KubeletExtraArgs: kubeletExtraArgs,
-		Arguments:     args,
-		PreBootstrap:  payload.PreBootstrap,
-		PostBootstrap: payload.PostBootstrap,
-		MountOptions:  mounts,
+		Arguments:        args,
+		PreBootstrap:     payload.PreBootstrap,
+		PostBootstrap:    payload.PostBootstrap,
+		MountOptions:     mounts,
 	}
 	out := &bytes.Buffer{}
 	tmpl := template.New("userData").Funcs(template.FuncMap{
@@ -219,7 +249,7 @@ func (ctx *EksInstanceGroupContext) GetAddedTags(asgName string) []*autoscaling.
 		configuration = instanceGroup.GetEKSConfiguration()
 		clusterName   = configuration.GetClusterName()
 		annotations   = instanceGroup.GetAnnotations()
-		labels 	      = configuration.GetLabels()
+		labels        = configuration.GetLabels()
 		taints        = configuration.GetTaints()
 	)
 
@@ -328,10 +358,10 @@ func (ctx *EksInstanceGroupContext) GetTaintList() []string {
 	return taintList
 }
 
-func (ctx *EksInstanceGroupContext) GetLabelList() []string {
+func (ctx *EksInstanceGroupContext) GetComputedLabels() map[string]string {
 	var (
-		labelList     []string
 		isOverride    bool
+		labelMap      = make(map[string]string)
 		instanceGroup = ctx.GetInstanceGroup()
 		annotations   = instanceGroup.GetAnnotations()
 		configuration = instanceGroup.GetEKSConfiguration()
@@ -341,7 +371,7 @@ func (ctx *EksInstanceGroupContext) GetLabelList() []string {
 	// get custom labels
 	if len(customLabels) > 0 {
 		for k, v := range customLabels {
-			labelList = append(labelList, fmt.Sprintf("%v=%v", k, v))
+			labelMap[k] = v
 		}
 	}
 
@@ -350,34 +380,49 @@ func (ctx *EksInstanceGroupContext) GetLabelList() []string {
 		isOverride = true
 		overrideLabels := strings.Split(val, ",")
 		for _, label := range overrideLabels {
-			labelList = append(labelList, label)
+			keyVal := strings.Split(label, "=")
+			labelMap[keyVal[0]] = keyVal[1]
 		}
 	}
 
 	if !isOverride {
 		// add default labels
-		labelList = append(labelList, fmt.Sprintf(RoleNewLabelFmt, instanceGroup.GetName()))
+		labelMap[RoleNewLabel] = instanceGroup.GetName()
 
 		// add the old style role label if the cluster's k8s version is < 1.16
 		clusterVersion := ctx.DiscoveredState.GetClusterVersion()
 		ver, err := semver.NewVersion(clusterVersion)
 		if err != nil {
 			ctx.Log.Error(err, "Failed parsing the cluster's kubernetes version", "instancegroup", instanceGroup.GetName())
-			labelList = append(labelList, fmt.Sprintf(RoleOldLabelFmt, instanceGroup.GetName()))
+			labelMap[fmt.Sprintf(RoleOldLabel, instanceGroup.GetName())] = ""
 		} else {
 			c, _ := semver.NewConstraint("< 1.16-0")
 			if c.Check(ver) {
-				labelList = append(labelList, fmt.Sprintf(RoleOldLabelFmt, instanceGroup.GetName()))
+				labelMap[fmt.Sprintf(RoleOldLabel, instanceGroup.GetName())] = ""
 			}
 		}
 	}
 
 	if configuration.GetSpotPrice() == "" {
-		labelList = append(labelList, fmt.Sprintf(InstanceMgrLabelFmt, "lifecycle", v1alpha1.LifecycleStateNormal))
+		labelMap[InstanceMgrLifecycleLabel] = v1alpha1.LifecycleStateNormal
 	} else {
-		labelList = append(labelList, fmt.Sprintf(InstanceMgrLabelFmt, "lifecycle", v1alpha1.LifecycleStateSpot))
+		labelMap[InstanceMgrLifecycleLabel] = v1alpha1.LifecycleStateSpot
 	}
 
+	return labelMap
+}
+
+func (ctx *EksInstanceGroupContext) GetLabelList() []string {
+	var (
+		labelList []string
+	)
+
+	for key, value := range ctx.GetComputedLabels() {
+		if value == "" {
+			value = "\"\""
+		}
+		labelList = append(labelList, fmt.Sprintf("%v=%v", key, value))
+	}
 	sort.Strings(labelList)
 	return labelList
 }
@@ -733,25 +778,25 @@ func (ctx *EksInstanceGroupContext) UpdateLifecycleHooks(asgName string) error {
 	if hooks, ok := ctx.GetAddedHooks(); ok {
 		for _, hook := range hooks {
 			input := &autoscaling.PutLifecycleHookInput{
-				AutoScalingGroupName:  aws.String(asgName),
-				LifecycleHookName:     aws.String(hook.Name),
-				DefaultResult:         aws.String(hook.DefaultResult),
-				HeartbeatTimeout:      aws.Int64(hook.HeartbeatTimeout),
-				LifecycleTransition:   aws.String(hook.Lifecycle),
+				AutoScalingGroupName: aws.String(asgName),
+				LifecycleHookName:    aws.String(hook.Name),
+				DefaultResult:        aws.String(hook.DefaultResult),
+				HeartbeatTimeout:     aws.Int64(hook.HeartbeatTimeout),
+				LifecycleTransition:  aws.String(hook.Lifecycle),
 			}
-			
+
 			if !common.StringEmpty(hook.Metadata) {
 				input.NotificationMetadata = aws.String(hook.Metadata)
 			}
-			
+
 			if !common.StringEmpty(hook.RoleArn) {
 				input.RoleARN = aws.String(hook.RoleArn)
 			}
-			
+
 			if !common.StringEmpty(hook.NotificationArn) {
 				input.NotificationTargetARN = aws.String(hook.NotificationArn)
 			}
-            
+
 			if err := ctx.AwsWorker.CreateLifecycleHook(input); err != nil {
 				return errors.Wrapf(err, "failed to add lifecycle hook %v", hook)
 			}

--- a/controllers/provisioners/eks/helpers_test.go
+++ b/controllers/provisioners/eks/helpers_test.go
@@ -55,9 +55,9 @@ func TestAutoscalerTags(t *testing.T) {
 
 	ig.Spec.EKSSpec.EKSConfiguration.Taints = []corev1.Taint{}
 	ig.Spec.EKSSpec.EKSConfiguration.Taints = append(ig.Spec.EKSSpec.EKSConfiguration.Taints, corev1.Taint{
-		Key:       "red",
-		Value:     "green",
-		Effect:    "NoSchedule",
+		Key:    "red",
+		Value:  "green",
+		Effect: "NoSchedule",
 	})
 	ctx := MockContext(ig, k, w)
 
@@ -65,7 +65,7 @@ func TestAutoscalerTags(t *testing.T) {
 	expectedTags := make(map[string]string)
 
 	expectedTags["k8s.io/cluster-autoscaler/enabled"] = "true"
-	expectedTags["k8s.io/cluster-autoscaler/" + ig.Spec.EKSSpec.EKSConfiguration.EksClusterName] = "owned"
+	expectedTags["k8s.io/cluster-autoscaler/"+ig.Spec.EKSSpec.EKSConfiguration.EksClusterName] = "owned"
 	expectedTags["k8s.io/cluster-autoscaler/node-template/label/foo"] = "bar"
 	expectedTags["k8s.io/cluster-autoscaler/node-template/taint/red"] = "green:NoSchedule"
 
@@ -73,12 +73,11 @@ func TestAutoscalerTags(t *testing.T) {
 	for _, tag := range tagSlice {
 		tags[*tag.Key] = *tag.Value
 	}
-	for expectedKey, expectedValue  := range expectedTags {
+	for expectedKey, expectedValue := range expectedTags {
 		if tags[expectedKey] != expectedValue {
-			t.Fatalf("Expected %v=%v, Got %v",expectedKey,expectedValue,tags[expectedKey])
+			t.Fatalf("Expected %v=%v, Got %v", expectedKey, expectedValue, tags[expectedKey])
 		}
 	}
-
 
 }
 
@@ -321,7 +320,12 @@ func TestGetLabelList(t *testing.T) {
 				Client: k.Kubernetes,
 			},
 			Cluster: &eks.Cluster{
-				Version: aws.String(tc.clusterVersion),
+				CertificateAuthority: &eks.Certificate{
+					Data: aws.String(""),
+				},
+				Endpoint:           aws.String("foo.amazonaws.com"),
+				ResourcesVpcConfig: &eks.VpcConfigResponse{},
+				Version:            aws.String(tc.clusterVersion),
 			},
 		})
 		if tc.spotPrice == "" {
@@ -505,42 +509,46 @@ func TestGetUserDataStages(t *testing.T) {
 
 func TestBootstrapDataForOSFamily(t *testing.T) {
 	var (
-		k             = MockKubernetesClientSet()
-		linuxIg       = MockInstanceGroup()
-		windowsIg            = MockWindowsInstanceGroup()
-		asgMock       = NewAutoScalingMocker()
-		iamMock       = NewIamMocker()
-		eksMock       = NewEksMocker()
-		ec2Mock       = NewEc2Mocker()
+		k              = MockKubernetesClientSet()
+		bottleRocketIg = MockBottleRocketInstanceGroup()
+		linuxIg        = MockInstanceGroup()
+		windowsIg      = MockWindowsInstanceGroup()
+		asgMock        = NewAutoScalingMocker()
+		iamMock        = NewIamMocker()
+		eksMock        = NewEksMocker()
+		ec2Mock        = NewEc2Mocker()
 	)
 
 	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 
 	tests := []struct {
-		ig        *v1alpha1.InstanceGroup
+		ig                       *v1alpha1.InstanceGroup
 		expectedScriptSubstrings string
 	}{
 		{
-			ig: linuxIg,
+			ig:                       linuxIg,
 			expectedScriptSubstrings: "/etc/eks/bootstrap.sh",
 		},
 		{
-			ig: windowsIg,
+			ig:                       windowsIg,
 			expectedScriptSubstrings: "<powershell>",
+		},
+		{
+			ig:                       bottleRocketIg,
+			expectedScriptSubstrings: "[settings.kubernetes]",
 		},
 	}
 
 	for i, tc := range tests {
 		t.Logf("Test #%v - %+v", i, tc)
 		ctx := MockContext(tc.ig, k, w)
-		basicUserData := ctx.GetBasicUserData("", "","", UserDataPayload{}, []MountOpts{} )
+		basicUserData := ctx.GetBasicUserData("", "", "", UserDataPayload{}, []MountOpts{})
 		basicUserDataDecoded, _ := base64.StdEncoding.DecodeString(basicUserData)
 		basicUserDataString := string(basicUserDataDecoded)
 		if !strings.Contains(basicUserDataString, tc.expectedScriptSubstrings) {
-			t.Fatalf("Cound not find expected string %v script in %v",tc.expectedScriptSubstrings, basicUserDataString)
+			t.Fatalf("Cound not find expected string %v script in %v", tc.expectedScriptSubstrings, basicUserDataString)
 		}
 	}
-
 
 }
 

--- a/controllers/provisioners/eks/helpers_test.go
+++ b/controllers/provisioners/eks/helpers_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/aws/aws-sdk-go/service/eks"
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	awsprovider "github.com/keikoproj/instance-manager/controllers/providers/aws"
 	kubeprovider "github.com/keikoproj/instance-manager/controllers/providers/kubernetes"
@@ -319,14 +318,7 @@ func TestGetLabelList(t *testing.T) {
 			Publisher: kubeprovider.EventPublisher{
 				Client: k.Kubernetes,
 			},
-			Cluster: &eks.Cluster{
-				CertificateAuthority: &eks.Certificate{
-					Data: aws.String(""),
-				},
-				Endpoint:           aws.String("foo.amazonaws.com"),
-				ResourcesVpcConfig: &eks.VpcConfigResponse{},
-				Version:            aws.String(tc.clusterVersion),
-			},
+			Cluster: MockEksCluster(tc.clusterVersion),
 		})
 		if tc.spotPrice == "" {
 			tc.expectedLabels = append(tc.expectedLabels, defaultLifecycleLable)

--- a/controllers/provisioners/eks/update_test.go
+++ b/controllers/provisioners/eks/update_test.go
@@ -109,7 +109,12 @@ func TestUpdateWithDriftRotationPositive(t *testing.T) {
 		},
 		ClusterNodes: nodes,
 		Cluster: &eks.Cluster{
-			Version: aws.String("1.15"),
+			CertificateAuthority: &eks.Certificate{
+				Data: aws.String(""),
+			},
+			Endpoint:           aws.String("foo.amazonaws.com"),
+			ResourcesVpcConfig: &eks.VpcConfigResponse{},
+			Version:            aws.String("1.15"),
 		},
 	})
 
@@ -138,7 +143,12 @@ func TestUpdateWithRotationPositive(t *testing.T) {
 			Client: k.Kubernetes,
 		},
 		Cluster: &eks.Cluster{
-			Version: aws.String("1.15"),
+			CertificateAuthority: &eks.Certificate{
+				Data: aws.String(""),
+			},
+			Endpoint:           aws.String("foo.amazonaws.com"),
+			ResourcesVpcConfig: &eks.VpcConfigResponse{},
+			Version:            aws.String("1.15"),
 		},
 	})
 
@@ -191,7 +201,12 @@ func TestUpdateWithRotationPositive(t *testing.T) {
 		},
 		ClusterNodes: nodes,
 		Cluster: &eks.Cluster{
-			Version: aws.String("1.15"),
+			CertificateAuthority: &eks.Certificate{
+				Data: aws.String(""),
+			},
+			Endpoint:           aws.String("foo.amazonaws.com"),
+			ResourcesVpcConfig: &eks.VpcConfigResponse{},
+			Version:            aws.String("1.15"),
 		},
 	})
 
@@ -301,7 +316,12 @@ func TestLaunchConfigurationDrifted(t *testing.T) {
 				TargetResource: tc.input,
 			},
 			Cluster: &eks.Cluster{
-				Version: aws.String("1.15"),
+				CertificateAuthority: &eks.Certificate{
+					Data: aws.String(""),
+				},
+				Endpoint:           aws.String("foo.amazonaws.com"),
+				ResourcesVpcConfig: &eks.VpcConfigResponse{},
+				Version:            aws.String("1.15"),
 			},
 		})
 		got := ctx.DiscoveredState.ScalingConfiguration.Drifted(existingConfig)
@@ -343,7 +363,12 @@ func TestUpdateScalingGroupNegative(t *testing.T) {
 			AwsWorker: w,
 		},
 		Cluster: &eks.Cluster{
-			Version: aws.String("1.15"),
+			CertificateAuthority: &eks.Certificate{
+				Data: aws.String(""),
+			},
+			Endpoint:           aws.String("foo.amazonaws.com"),
+			ResourcesVpcConfig: &eks.VpcConfigResponse{},
+			Version:            aws.String("1.15"),
 		},
 	})
 
@@ -426,6 +451,13 @@ func TestScalingGroupUpdatePredicate(t *testing.T) {
 	for i, tc := range tests {
 		t.Logf("Test #%v", i)
 		ctx.SetDiscoveredState(&DiscoveredState{
+			Cluster: &eks.Cluster{
+				CertificateAuthority: &eks.Certificate{
+					Data: aws.String(""),
+				},
+				Endpoint:           aws.String("foo.amazonaws.com"),
+				ResourcesVpcConfig: &eks.VpcConfigResponse{},
+			},
 			Publisher: kubeprovider.EventPublisher{
 				Client: k.Kubernetes,
 			},

--- a/controllers/provisioners/eks/update_test.go
+++ b/controllers/provisioners/eks/update_test.go
@@ -108,14 +108,7 @@ func TestUpdateWithDriftRotationPositive(t *testing.T) {
 			Arn: aws.String("some-instance-arn"),
 		},
 		ClusterNodes: nodes,
-		Cluster: &eks.Cluster{
-			CertificateAuthority: &eks.Certificate{
-				Data: aws.String(""),
-			},
-			Endpoint:           aws.String("foo.amazonaws.com"),
-			ResourcesVpcConfig: &eks.VpcConfigResponse{},
-			Version:            aws.String("1.15"),
-		},
+		Cluster:      MockEksCluster("1.15"),
 	})
 
 	err = ctx.Update()
@@ -142,14 +135,7 @@ func TestUpdateWithRotationPositive(t *testing.T) {
 		Publisher: kubeprovider.EventPublisher{
 			Client: k.Kubernetes,
 		},
-		Cluster: &eks.Cluster{
-			CertificateAuthority: &eks.Certificate{
-				Data: aws.String(""),
-			},
-			Endpoint:           aws.String("foo.amazonaws.com"),
-			ResourcesVpcConfig: &eks.VpcConfigResponse{},
-			Version:            aws.String("1.15"),
-		},
+		Cluster: MockEksCluster("1.15"),
 	})
 
 	input := &autoscaling.CreateLaunchConfigurationInput{
@@ -200,14 +186,7 @@ func TestUpdateWithRotationPositive(t *testing.T) {
 			TargetResource: mockLaunchConfig,
 		},
 		ClusterNodes: nodes,
-		Cluster: &eks.Cluster{
-			CertificateAuthority: &eks.Certificate{
-				Data: aws.String(""),
-			},
-			Endpoint:           aws.String("foo.amazonaws.com"),
-			ResourcesVpcConfig: &eks.VpcConfigResponse{},
-			Version:            aws.String("1.15"),
-		},
+		Cluster:      MockEksCluster("1.15"),
 	})
 
 	err = ctx.Update()
@@ -315,14 +294,7 @@ func TestLaunchConfigurationDrifted(t *testing.T) {
 				AwsWorker:      w,
 				TargetResource: tc.input,
 			},
-			Cluster: &eks.Cluster{
-				CertificateAuthority: &eks.Certificate{
-					Data: aws.String(""),
-				},
-				Endpoint:           aws.String("foo.amazonaws.com"),
-				ResourcesVpcConfig: &eks.VpcConfigResponse{},
-				Version:            aws.String("1.15"),
-			},
+			Cluster: MockEksCluster("1.15"),
 		})
 		got := ctx.DiscoveredState.ScalingConfiguration.Drifted(existingConfig)
 		g.Expect(got).To(gomega.Equal(tc.expected))
@@ -362,14 +334,7 @@ func TestUpdateScalingGroupNegative(t *testing.T) {
 		ScalingConfiguration: &scaling.LaunchConfiguration{
 			AwsWorker: w,
 		},
-		Cluster: &eks.Cluster{
-			CertificateAuthority: &eks.Certificate{
-				Data: aws.String(""),
-			},
-			Endpoint:           aws.String("foo.amazonaws.com"),
-			ResourcesVpcConfig: &eks.VpcConfigResponse{},
-			Version:            aws.String("1.15"),
-		},
+		Cluster: MockEksCluster("1.15"),
 	})
 
 	asgMock.UpdateAutoScalingGroupErr = errors.New("some-update-error")
@@ -451,13 +416,7 @@ func TestScalingGroupUpdatePredicate(t *testing.T) {
 	for i, tc := range tests {
 		t.Logf("Test #%v", i)
 		ctx.SetDiscoveredState(&DiscoveredState{
-			Cluster: &eks.Cluster{
-				CertificateAuthority: &eks.Certificate{
-					Data: aws.String(""),
-				},
-				Endpoint:           aws.String("foo.amazonaws.com"),
-				ResourcesVpcConfig: &eks.VpcConfigResponse{},
-			},
+			Cluster: MockEksCluster(""),
 			Publisher: kubeprovider.EventPublisher{
 				Client: k.Kubernetes,
 			},


### PR DESCRIPTION
This PR leverages the os-family annotation introduced in #186 to support [BottleRocket](https://aws.amazon.com/bottlerocket/) AMIs on EKS self-managed node groups. 

Signed-off-by: Jonah Back <jonah@jonahback.com>