### PR TITLE
ManagedRole: use MD5 when name is exceeding limit

### DIFF
--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -16,7 +16,6 @@ limitations under the License.
 package eks
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
@@ -106,8 +105,14 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 		roleName = configuration.GetRoleName()
 		instanceProfileName = configuration.GetInstanceProfileName()
 	} else {
-		roleName = fmt.Sprintf("%v-%v-%v", clusterName, instanceGroup.GetNamespace(), instanceGroup.GetName())
-		instanceProfileName = fmt.Sprintf("%v-%v-%v", clusterName, instanceGroup.GetNamespace(), instanceGroup.GetName())
+		roleName = ctx.ResourcePrefix
+		instanceProfileName = ctx.ResourcePrefix
+		if len(roleName) > 63 {
+			// use a hash of the actual name in case we exceed the max length
+			roleName = common.StringMD5(roleName)
+			instanceProfileName = common.StringMD5(instanceProfileName)
+		}
+
 	}
 
 	// cache the instancegroup IAM role if it exists

--- a/controllers/provisioners/eks/create.go
+++ b/controllers/provisioners/eks/create.go
@@ -162,6 +162,11 @@ func (ctx *EksInstanceGroupContext) CreateManagedRole() error {
 		return nil
 	}
 
+	if len(roleName) > 63 {
+		// use a hash of the actual name in case we exceed the max length
+		roleName = common.StringMD5(roleName)
+	}
+
 	role, profile, err := ctx.AwsWorker.CreateScalingGroupRole(roleName)
 	if err != nil {
 		return errors.Wrap(err, "failed to create scaling group role")


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <Eytan_Avisror@hotmail.com>

Fixes #202 

For IAM role/profile creation/deletion, this uses an MD5 hash of the resource name if the resource name is too long