### PR TITLE
Add Github Actions for unit test and image publication

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,83 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+    - v*
+  pull_request:
+    branches: [ master ]
+  
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.15
+  
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Test
+      run: |
+        go test -v ./controllers/... -coverprofile coverage.txt
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.txt
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        install: true
+        version: latest
+        
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+  
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+ 
+    -
+      name: Login to GitHub Container Registry
+      uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
+
+    -
+      name: Docker meta
+      id: docker_meta
+      uses: crazy-max/ghaction-docker-meta@v1
+      with:
+        images: ${{ github.repository_owner }}/instancemgr,ghcr.io/${{ github.repository_owner }}/instance-manager
+    -
+      name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        platforms: linux/amd64,linux/arm/v7,linux/arm64
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+       

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
     tags:
-    - v*
+    - *
   pull_request:
     branches: [ master ]
   
@@ -42,7 +42,7 @@ jobs:
       uses: docker/login-action@v1 
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
+        username: ${{ secrets.CR_USERNAME }}
         password: ${{ secrets.CR_PAT }}
 
     -

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,26 +9,6 @@ on:
     branches: [ master ]
   
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.15
-  
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: Test
-      run: |
-        go test -v ./controllers/... -coverprofile coverage.txt
-    - name: Upload to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.txt
-
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.13
   
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.15
+  
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Test
+      run: |
+        go test -v ./controllers/... -coverprofile coverage.txt
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.txt
+       


### PR DESCRIPTION
Closes #191 
Partially implements #137

This PR adds two GitHub actions - one for running unit tests, and another for publishing images. 

The image publication adds several new features above and beyond the existing image publication today:
- MultiArch images are now published (see [example](https://hub.docker.com/layers/jbacklegalzoom/instancemgr/pr-1/images/sha256-502fb4cd61290eb91c2cc9f63794c971b2cf73859eee2770d2222359411d66c4?context=repo))
- PR images are automatically published
- Images can easily be published to multiple repos - this PR adds GitHub container registry, which does not have any limits on downloading containers. 
 

Before any merge, this would needs secrets added to this repo for pushing to GHCR and DockerHub