### PR TITLE
Fix premature upgrade completion

### DIFF
--- a/api/v1alpha1/instancegroup_types.go
+++ b/api/v1alpha1/instancegroup_types.go
@@ -309,6 +309,7 @@ type InstanceGroupStatus struct {
 	ActiveScalingGroupName        string                   `json:"activeScalingGroupName,omitempty"`
 	NodesArn                      string                   `json:"nodesInstanceRoleArn,omitempty"`
 	StrategyResourceName          string                   `json:"strategyResourceName,omitempty"`
+	StrategyResourceNamespace     string                   `json:"strategyResourceNamespace,omitempty"`
 	UsingSpotRecommendation       bool                     `json:"usingSpotRecommendation,omitempty"`
 	Lifecycle                     string                   `json:"lifecycle,omitempty"`
 	ConfigHash                    string                   `json:"configMD5,omitempty"`
@@ -897,8 +898,16 @@ func (status *InstanceGroupStatus) GetStrategyResourceName() string {
 	return status.StrategyResourceName
 }
 
+func (status *InstanceGroupStatus) GetStrategyResourceNamespace() string {
+	return status.StrategyResourceNamespace
+}
+
 func (status *InstanceGroupStatus) SetStrategyResourceName(name string) {
 	status.StrategyResourceName = name
+}
+
+func (status *InstanceGroupStatus) SetStrategyResourceNamespace(namespace string) {
+	status.StrategyResourceNamespace = namespace
 }
 
 func (status *InstanceGroupStatus) GetCurrentMin() int {

--- a/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
+++ b/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
@@ -419,6 +419,8 @@ spec:
               type: string
             strategyResourceName:
               type: string
+            strategyResourceNamespace:
+              type: string
             usingSpotRecommendation:
               type: boolean
           type: object

--- a/controllers/providers/kubernetes/crd.go
+++ b/controllers/providers/kubernetes/crd.go
@@ -270,20 +270,6 @@ func IsResourceActive(kube dynamic.Interface, instanceGroup *v1alpha1.InstanceGr
 	return true
 }
 
-func IsPathValue(resource unstructured.Unstructured, path, value string) bool {
-	val, err := GetUnstructuredPath(&resource, path)
-	if err != nil {
-		log.Error(err, "failed to get unstructured path from resource", "path", path)
-		return false
-	}
-
-	if strings.EqualFold(val, value) {
-		return true
-	}
-
-	return false
-}
-
 func GetResources(kube dynamic.Interface, instanceGroup *v1alpha1.InstanceGroup, resource *unstructured.Unstructured) ([]*unstructured.Unstructured, []*unstructured.Unstructured, error) {
 	var (
 		status            = instanceGroup.GetStatus()

--- a/controllers/providers/kubernetes/utils.go
+++ b/controllers/providers/kubernetes/utils.go
@@ -263,3 +263,17 @@ func IsStorageError(err error) bool {
 	}
 	return false
 }
+
+func IsPathValue(resource unstructured.Unstructured, path, value string) bool {
+	val, err := GetUnstructuredPath(&resource, path)
+	if err != nil {
+		log.Error(err, "failed to get unstructured path from resource", "path", path)
+		return false
+	}
+
+	if strings.EqualFold(val, value) {
+		return true
+	}
+
+	return false
+}

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -98,7 +98,7 @@ func (ctx *EksInstanceGroupContext) Update() error {
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
 			if aerr.Code() == autoscaling.ErrCodeScalingActivityInProgressFault {
-				ctx.Log.Info("autoscaling activity in progress, will requeue", "instancegroup", instanceGroup.GetName())
+				ctx.Log.Info("cannot update scaling group due to autoscaling activity in progress", "instancegroup", instanceGroup.GetName())
 				return nil
 			}
 		}

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	"github.com/keikoproj/instance-manager/controllers/common"
+	kubeprovider "github.com/keikoproj/instance-manager/controllers/providers/kubernetes"
 	"github.com/keikoproj/instance-manager/controllers/provisioners/eks/scaling"
 )
 
@@ -84,6 +85,11 @@ func (ctx *EksInstanceGroupContext) Update() error {
 		ScalingGroup: state.ScalingGroup,
 	}) {
 		ctx.Log.Info("node rotation required", "instancegroup", instanceGroup.GetName(), "scalingconfig", config.Name)
+		rotationNeeded = true
+	}
+
+	if kubeprovider.IsResourceActive(ctx.KubernetesClient.KubeDynamic, instanceGroup) {
+		ctx.Log.Info("upgrade resource is still active", "instancegroup", instanceGroup.GetName(), "scalingconfig", config.Name)
 		rotationNeeded = true
 	}
 

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -97,7 +97,8 @@ func (ctx *EksInstanceGroupContext) Update() error {
 	err = ctx.UpdateScalingGroup(config.Name)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() != autoscaling.ErrCodeScalingActivityInProgressFault {
+			if aerr.Code() == autoscaling.ErrCodeScalingActivityInProgressFault {
+				ctx.Log.Info("autoscaling activity in progress, will requeue", "instancegroup", instanceGroup.GetName())
 				return nil
 			}
 		}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -62,6 +62,7 @@ ec2:CreateLaunchTemplateVersion
 ec2:ModifyLaunchTemplate
 ec2:DeleteLaunchTemplate
 ec2:DeleteLaunchTemplateVersions
+ec2:RunInstances
 autoscaling:CreateOrUpdateTags
 autoscaling:DeleteTags
 autoscaling:SuspendProcesses


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <Eytan_Avisror@hotmail.com>

Fixes #211 

This marks rotationNeeded if the custom resource for node rotation is still active.
Without this, we are exposed to a race condition where if during an upgrade all nodes are ready we may mark it completed prematurely.

This requires adding another status field to cache the upgrade resource's namespace

TBD:
- [x] functional test