### PR TITLE
fix: remove explicit architecture in go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
The explicit GOARCH variable in the Dockerfile causes ARM images to contain an AMD64 executable. This variable is unnecessary, since go will inspect the system to figure out what architecture it is running in. 

Signed-off-by: Jonah Back <jonah@jonahback.com>