### PR TITLE
Avoid launch template creation loop

### DIFF
--- a/api/v1alpha1/instancegroup_types.go
+++ b/api/v1alpha1/instancegroup_types.go
@@ -914,10 +914,13 @@ func (status *InstanceGroupStatus) GetActiveLaunchTemplateName() string {
 
 func (status *InstanceGroupStatus) SetActiveLaunchConfigurationName(name string) {
 	status.ActiveLaunchConfigurationName = name
+	status.ActiveLaunchTemplateName = ""
+	status.LatestTemplateVersion = ""
 }
 
 func (status *InstanceGroupStatus) SetActiveLaunchTemplateName(name string) {
 	status.ActiveLaunchTemplateName = name
+	status.ActiveLaunchConfigurationName = ""
 }
 
 func (status *InstanceGroupStatus) SetLatestTemplateVersion(version string) {

--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -78,10 +78,8 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 	status.SetLifecycle(v1alpha1.LifecycleStateNormal)
 
 	if spec.IsLaunchConfiguration() {
-		input := &scaling.DiscoverConfigurationInput{}
-
-		if status.GetActiveLaunchConfigurationName() != "" {
-			input.TargetConfigName = status.GetActiveLaunchConfigurationName()
+		input := &scaling.DiscoverConfigurationInput{
+			TargetConfigName: status.GetActiveLaunchConfigurationName(),
 		}
 
 		var (
@@ -93,14 +91,12 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 			return errors.Wrap(err, "failed to discover launch configuration")
 		}
 		state.ScalingConfiguration = config
-
+		status.SetActiveLaunchConfigurationName(config.Name())
 	}
 
 	if spec.IsLaunchTemplate() {
-		input := &scaling.DiscoverConfigurationInput{}
-
-		if status.GetActiveLaunchTemplateName() != "" {
-			input.TargetConfigName = status.GetActiveLaunchTemplateName()
+		input := &scaling.DiscoverConfigurationInput{
+			TargetConfigName: status.GetActiveLaunchTemplateName(),
 		}
 
 		var (
@@ -112,6 +108,7 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 			return errors.Wrap(err, "failed to discover launch template")
 		}
 		state.ScalingConfiguration = config
+		status.SetActiveLaunchTemplateName(config.Name())
 
 		if mixedInstancesPolicy != nil {
 			if ratio := common.IntOrStrValue(mixedInstancesPolicy.SpotRatio); ratio > 0 {

--- a/controllers/provisioners/eks/create_test.go
+++ b/controllers/provisioners/eks/create_test.go
@@ -191,7 +191,6 @@ func TestCreateNoOp(t *testing.T) {
 
 	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock)
 	ctx := MockContext(ig, k, w)
-
 	// skip role creation
 	ig.GetEKSConfiguration().SetInstanceProfileName("some-profile")
 	ig.GetEKSConfiguration().SetRoleName("some-role")
@@ -200,6 +199,7 @@ func TestCreateNoOp(t *testing.T) {
 		LaunchConfigurationName: aws.String("some-launch-config"),
 	}
 	lc := &scaling.LaunchConfiguration{
+		AwsWorker:      w,
 		TargetResource: mockLaunchConfiguration,
 	}
 

--- a/controllers/provisioners/eks/scaling/interface.go
+++ b/controllers/provisioners/eks/scaling/interface.go
@@ -45,7 +45,8 @@ type DeleteConfigurationInput struct {
 }
 
 type DiscoverConfigurationInput struct {
-	ScalingGroup *autoscaling.Group
+	ScalingGroup     *autoscaling.Group
+	TargetConfigName string
 }
 
 type CreateConfigurationInput struct {

--- a/controllers/provisioners/eks/scaling/launchconfig.go
+++ b/controllers/provisioners/eks/scaling/launchconfig.go
@@ -64,7 +64,7 @@ func (lc *LaunchConfiguration) Discover(input *DiscoverConfigurationInput) error
 	} else if input.ScalingGroup != nil {
 		targetName = awsprovider.GetScalingConfigName(input.ScalingGroup)
 	} else {
-		// cannot discovery without scaling group name or launch config name
+		// cannot discover without scaling group name or launch config name
 		return nil
 	}
 

--- a/controllers/provisioners/eks/scaling/launchconfig.go
+++ b/controllers/provisioners/eks/scaling/launchconfig.go
@@ -58,10 +58,15 @@ func (lc *LaunchConfiguration) Discover(input *DiscoverConfigurationInput) error
 	}
 	lc.ResourceList = launchConfigurations
 
-	if input.ScalingGroup == nil {
+	var targetName string
+	if !common.StringEmpty(input.TargetConfigName) {
+		targetName = input.TargetConfigName
+	} else if input.ScalingGroup != nil {
+		targetName = awsprovider.GetScalingConfigName(input.ScalingGroup)
+	} else {
+		// cannot discovery without scaling group name or launch config name
 		return nil
 	}
-	targetName := aws.StringValue(input.ScalingGroup.LaunchConfigurationName)
 
 	for _, config := range launchConfigurations {
 		name := aws.StringValue(config.LaunchConfigurationName)

--- a/controllers/provisioners/eks/scaling/launchtemplate.go
+++ b/controllers/provisioners/eks/scaling/launchtemplate.go
@@ -111,10 +111,7 @@ func (lt *LaunchTemplate) Create(input *CreateConfigurationInput) error {
 		}); err != nil {
 			return err
 		}
-	} else {
-		if !lt.Drifted(input) {
-			return nil
-		}
+	} else if lt.Drifted(input) {
 		createdVersion, err := lt.CreateLaunchTemplateVersion(&ec2.CreateLaunchTemplateVersionInput{
 			LaunchTemplateName: aws.String(input.Name),
 			LaunchTemplateData: templateData,

--- a/controllers/provisioners/eks/scaling/launchtemplate.go
+++ b/controllers/provisioners/eks/scaling/launchtemplate.go
@@ -62,16 +62,14 @@ func (lt *LaunchTemplate) Discover(input *DiscoverConfigurationInput) error {
 	}
 	lt.ResourceList = launchTemplates
 
-	if input.ScalingGroup == nil {
-		return nil
-	}
-
 	var targetName string
-	if awsprovider.IsUsingLaunchTemplate(input.ScalingGroup) {
-		targetName = aws.StringValue(input.ScalingGroup.LaunchTemplate.LaunchTemplateName)
-	}
-	if awsprovider.IsUsingMixedInstances(input.ScalingGroup) {
-		targetName = aws.StringValue(input.ScalingGroup.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateName)
+	if !common.StringEmpty(input.TargetConfigName) {
+		targetName = input.TargetConfigName
+	} else if input.ScalingGroup != nil {
+		targetName = awsprovider.GetScalingConfigName(input.ScalingGroup)
+	} else {
+		// cannot discovery without scaling group name or launch template name
+		return nil
 	}
 
 	for _, config := range launchTemplates {
@@ -114,6 +112,9 @@ func (lt *LaunchTemplate) Create(input *CreateConfigurationInput) error {
 			return err
 		}
 	} else {
+		if !lt.Drifted(input) {
+			return nil
+		}
 		createdVersion, err := lt.CreateLaunchTemplateVersion(&ec2.CreateLaunchTemplateVersionInput{
 			LaunchTemplateName: aws.String(input.Name),
 			LaunchTemplateData: templateData,

--- a/controllers/provisioners/eks/scaling/launchtemplate.go
+++ b/controllers/provisioners/eks/scaling/launchtemplate.go
@@ -68,7 +68,7 @@ func (lt *LaunchTemplate) Discover(input *DiscoverConfigurationInput) error {
 	} else if input.ScalingGroup != nil {
 		targetName = awsprovider.GetScalingConfigName(input.ScalingGroup)
 	} else {
-		// cannot discovery without scaling group name or launch template name
+		// cannot discover without scaling group name or launch template name
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <eytan_avisror@intuit.com>

Fixes #223 

Background: This bug only happens on the creation flow - when the launch template is created, but the scaling group fails to create due to a launch template problem (e.g. bad AMI, missing permission, etc). In this case we never move on to update flow since the scaling group never gets created, and there is no logic to handle the case where the launch template already exist but the scaling group does not - so we enter an endless loop of creating new configurations until the CR value is fixed.

Desired behavior: The behavior should be that we create a scaling config once, if the downstream operation (e.g. creating a scaling group) fails due to a bad config, we should only create a new config/config version if there is a diff with the one we already created.
So if the user creates a resource with a bad AMI, we create a single config, and when we fail to use it, we continue failing without creation of new configs or config versions.
Once the resource has changed to reflect a different AMI (or other config), we create a new config version and try to use that instead.

- Discover launch templates on create flow as well - pass in a specific config name `TargetConfigName` in case it's cached in status in order to detect created launch config / template even if scaling group creation has failed in a previous reconcile.

- Always call `scalingConfig.Create()` in create scenario, the internal logic of `Create()` already checks if `IsProvisioned()` or not.

- Check if there is a drift before creating a new launch template version - if there is no drift avoid creating endless number of launch template versions until the problem is corrected via the CR.


- [x] BDD Passing
- [x] Test Switching between Template/Config