### PR TITLE
Remove Github Actions comment trigger

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -1,8 +1,6 @@
 name: functional-test
 
 on:
-  issue_comment:
-    types: [created]
   schedule:
     # run at 23:05 PM PST (cron uses UTC)
     - cron:  '5 15 * * *'
@@ -11,9 +9,7 @@ jobs:
 
   functional-test:
     name: functional-test
-    if: github.repository_owner == 'keikoproj' &&
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/ok-to-test')) ||
-        github.event_name == 'schedule'
+    if: github.repository_owner == 'keikoproj'
 
     runs-on: ubuntu-18.04
 
@@ -32,19 +28,6 @@ jobs:
           kubectl
           aws --version
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.sha }}
-
-      - name: docker-build-push
-        uses: docker/build-push-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: keikoproj/instance-manager-test
-          tags: ${{ github.sha }}
-
       - name: test
         env:
           AWS_REGION: us-west-2
@@ -62,5 +45,5 @@ jobs:
           HEAD=$(git rev-parse --short HEAD)
           aws eks update-kubeconfig --name $EKS_CLUSTER
           make install
-          kubectl set image -n instance-manager deployment/instance-manager instance-manager=keikoproj/instance-manager-test:${{ github.sha }}
+          kubectl set image -n instance-manager deployment/instance-manager instance-manager=keikoproj/instance-manager:master
           make bdd

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -10,7 +10,6 @@ jobs:
   functional-test:
     name: functional-test
     if: github.repository_owner == 'keikoproj'
-
     runs-on: ubuntu-18.04
 
     steps:
@@ -27,6 +26,11 @@ jobs:
           jq --version
           kubectl
           aws --version
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.sha }}
 
       - name: test
         env:

--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.sha }}
+          ref: master
 
       - name: test
         env:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # instance-manager
 
-[![Build Status](https://travis-ci.org/keikoproj/instance-manager.svg?branch=master)](https://travis-ci.org/keikoproj/instance-manager)
+![functional-test](https://github.com/keikoproj/instance-manager/workflows/functional-test/badge.svg)
+![push](https://github.com/keikoproj/instance-manager/workflows/push/badge.svg)
 [![codecov](https://codecov.io/gh/keikoproj/instance-manager/branch/master/graph/badge.svg)](https://codecov.io/gh/keikoproj/instance-manager)
 [![Go Report Card](https://goreportcard.com/badge/github.com/keikoproj/instance-manager)](https://goreportcard.com/report/github.com/keikoproj/instance-manager)
 [![slack](https://img.shields.io/badge/slack-join%20the%20conversation-ff69b4.svg)][SlackUrl]


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <eytan_avisror@intuit.com>

It seems you cannot publish images from fork based PRs, hence removing comment trigger for now.