### PR TITLE
fix: only update status if it changed to avoid infinite loops

### DIFF
--- a/controllers/instancegroup_controller.go
+++ b/controllers/instancegroup_controller.go
@@ -119,6 +119,7 @@ func (r *InstanceGroupReconciler) Reconcile(ctxt context.Context, req ctrl.Reque
 		r.Log.Error(err, "reconcile failed")
 		return ctrl.Result{}, err
 	}
+	existingStatus := instanceGroup.Status
 
 	// set/unset finalizer
 	r.SetFinalizer(instanceGroup)
@@ -200,7 +201,9 @@ func (r *InstanceGroupReconciler) Reconcile(ctxt context.Context, req ctrl.Reque
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	r.UpdateStatus(input.InstanceGroup)
+	if !reflect.DeepEqual(existingStatus, input.InstanceGroup.Status) {
+		r.UpdateStatus(input.InstanceGroup)
+	}
 	r.Finalize(instanceGroup)
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
Signed-off-by: Jonah Back <jonah@jonahback.com>

This PR checks the status subresource for changes before and after reconcile - and only triggers an update if anything changed. This is to avoid an infinite reconcile loop, which we noticed by seeing our controller constantly running at 100% of the requested CPU.