### PR TITLE
remove config hash when namespace is excluded

### DIFF
--- a/controllers/providers/kubernetes/utils.go
+++ b/controllers/providers/kubernetes/utils.go
@@ -22,6 +22,7 @@ import (
 	"html/template"
 	"os"
 	"os/user"
+	"reflect"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -253,6 +254,11 @@ func ParseCustomResourceYaml(raw string) (*unstructured.Unstructured, error) {
 
 func ConfigmapHash(cm *corev1.ConfigMap) string {
 	var buf strings.Builder
+
+	if reflect.DeepEqual(*cm, corev1.ConfigMap{}) {
+		return ""
+	}
+
 	cmStr := cm.String()
 	buf.WriteString(cmStr[strings.Index(cm.String(), ",Data:")+1:])
 	return common.StringMD5(buf.String())

--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -59,7 +59,6 @@ func New(p provisioners.ProvisionerInput) *EksInstanceGroupContext {
 		configuration = instanceGroup.GetEKSConfiguration()
 		status        = instanceGroup.GetStatus()
 		strategy      = instanceGroup.GetUpgradeStrategy()
-		configHash    = kubeprovider.ConfigmapHash(p.Configuration)
 	)
 
 	ctx := &EksInstanceGroupContext{
@@ -72,7 +71,6 @@ func New(p provisioners.ProvisionerInput) *EksInstanceGroupContext {
 	}
 
 	instanceGroup.SetState(v1alpha1.ReconcileInit)
-	status.SetConfigHash(configHash)
 	status.SetProvisioner(ProvisionerName)
 	status.SetStrategy(strategy.Type)
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/aws/aws-sdk-go v1.35.22
 	github.com/cucumber/godog v0.8.1
+	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.3.0
 	github.com/keikoproj/aws-auth v0.0.0-20210105225553-36322b72224f


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <eytan_avisror@intuit.com>

Fixes #235 

- Moves setting of config hash up to controller level, will now unset configHash field if configmap is nil/empty/does not exist.
- Refactors namespace exclusion logic into IsNamespaceExcluded method
- Refactors `UpdateStatus` to use patch instead of update, in order avoid metadata changes causing a reconcile loop - in k8s 1.18 managedFields was introduced along with a `time` field which causes this problem when using Update method. For now this implements a custom StatusPatch, in the future we might want something similar to #240 

- [x] BDD Passing

@backjo 