### PR TITLE
fix: bdd cleanup timing bug

### DIFF
--- a/.github/DEVELOPER.md
+++ b/.github/DEVELOPER.md
@@ -65,10 +65,13 @@ export KUBECONFIG=~/.kube/config
 
 export EKS_CLUSTER=my-eks-cluster
 export KEYPAIR_NAME=MyKeyPair
-export VPC_ID=vpc-EXAMPLE23dk9
 export AMI_ID=ami-EXAMPLEdk93
 export SECURITY_GROUPS=sg-EXAMPLE2323,sg-EXAMPLE4433
-export SUBNETS=subnet-EXAMPLE223d,subnet-EXAMPLEdkkf,subnet-EXAMPLEkkr9
+export NODE_SUBNETS=subnet-EXAMPLE223d,subnet-EXAMPLEdkkf,subnet-EXAMPLEkkr9
+
+# an existing role for nodes
+export NODE_ROLE_ARN=arn:aws:iam::123456789012:role/basic-eks-role
+export NODE_ROLE=basic-eks-role
 
 $ make bdd
 

--- a/test-bdd/main_test.go
+++ b/test-bdd/main_test.go
@@ -502,7 +502,13 @@ func (t *FunctionalTest) deleteAll() error {
 	}
 
 	// Delete configmap last
-	t.KubeClient.CoreV1().ConfigMaps("instance-manager").Delete(context.Background(), "instance-manager", metav1.DeleteOptions{})
+	var (
+		cmName      = "instance-manager"
+		cmNamespace = "instance-manager"
+		cmKind      = "ConfigMap"
+	)
+	log.Infof("BDD >> submitted deletion for %v %v/%v", cmKind, cmNamespace, cmName)
+	t.KubeClient.CoreV1().ConfigMaps(cmNamespace).Delete(context.Background(), cmName, metav1.DeleteOptions{})
 
 	return nil
 }

--- a/test-bdd/main_test.go
+++ b/test-bdd/main_test.go
@@ -437,15 +437,23 @@ func (t *FunctionalTest) deleteAll() error {
 			return err
 		}
 
-		t.DynamicClient.Resource(gvr.Resource).Namespace(resource.GetNamespace()).Delete(context.Background(), resource.GetName(), metav1.DeleteOptions{})
-		log.Infof("BDD >> submitted deletion for %v/%v", resource.GetNamespace(), resource.GetName())
+		var (
+			namespace = resource.GetNamespace()
+			name      = resource.GetName()
+			kind      = resource.GetKind()
+		)
+
+		if strings.EqualFold(kind, "ConfigMap") {
+			return nil
+		}
+
+		t.DynamicClient.Resource(gvr.Resource).Namespace(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+		log.Infof("BDD >> submitted deletion for %v %v/%v", kind, namespace, name)
 		return nil
 	}
 
 	var waitFn = func(path string, info os.FileInfo, err error) error {
-		var (
-			counter int
-		)
+		var counter int
 
 		if info.IsDir() || filepath.Ext(path) != ".yaml" {
 			return nil
@@ -456,15 +464,26 @@ func (t *FunctionalTest) deleteAll() error {
 			return err
 		}
 
+		var (
+			namespace = resource.GetNamespace()
+			name      = resource.GetName()
+			kind      = resource.GetKind()
+		)
+
+		if strings.EqualFold(kind, "ConfigMap") {
+			return nil
+		}
+
 		for {
 			if counter >= DefaultWaiterRetries {
 				return errors.New("waiter timed out waiting for deletion")
 			}
-			log.Infof("BDD >> waiting for resource deletion of %v/%v", resource.GetNamespace(), resource.GetName())
-			_, err := t.DynamicClient.Resource(gvr.Resource).Namespace(resource.GetNamespace()).Get(context.Background(), resource.GetName(), metav1.GetOptions{})
+
+			log.Infof("BDD >> waiting for %v deletion of %v/%v", kind, namespace, name)
+			_, err := t.DynamicClient.Resource(gvr.Resource).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 			if err != nil {
 				if kerrors.IsNotFound(err) {
-					log.Infof("BDD >> resource %v/%v is deleted", resource.GetNamespace(), resource.GetName())
+					log.Infof("BDD >> %v %v/%v is deleted", kind, namespace, name)
 					break
 				}
 			}
@@ -481,6 +500,9 @@ func (t *FunctionalTest) deleteAll() error {
 	if err := filepath.Walk("templates", waitFn); err != nil {
 		return err
 	}
+
+	// Delete configmap last
+	t.KubeClient.CoreV1().ConfigMaps("instance-manager").Delete(context.Background(), "instance-manager", metav1.DeleteOptions{})
 
 	return nil
 }

--- a/test-bdd/main_test.go
+++ b/test-bdd/main_test.go
@@ -62,8 +62,8 @@ const (
 	NodeStateReady = "ready"
 	NodeStateFound = "found"
 
-	DefaultWaiterInterval = time.Second * 30
-	DefaultWaiterRetries  = 40
+	DefaultWaiterInterval = time.Second * 15
+	DefaultWaiterRetries  = 80
 )
 
 var InstanceGroupSchema = schema.GroupVersionResource{


### PR DESCRIPTION
This fixes an issue where if the bdd fails it does not clean up properly by deleting the config map while the instance group is still being deleted - this leaves the controller in a bad state.

This is prevented by leaving the configmap deletion to the very end of deleteAll()

Also added resource kind to logging and made waiter polling interval shorter

- [x] BDD Passing