### PR TITLE
fix: Set InstanceTypes before provisioned early exit

### DIFF
--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -171,6 +171,12 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 	vpcID := aws.StringValue(cluster.ResourcesVpcConfig.VpcId)
 	state.SetVPCId(vpcID)
 
+	instanceTypes, err := ctx.AwsWorker.DescribeInstanceTypes()
+	if err != nil {
+		return errors.Wrap(err, "failed to discover instance types")
+	}
+	state.SetInstanceTypeInfo(instanceTypes)
+
 	// find all owned scaling groups
 	ownedScalingGroups := ctx.findOwnedScalingGroups(scalingGroups)
 	state.SetOwnedScalingGroups(ownedScalingGroups)
@@ -205,12 +211,6 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 	status.SetActiveScalingGroupName(asgName)
 	status.SetCurrentMin(int(aws.Int64Value(targetScalingGroup.MinSize)))
 	status.SetCurrentMax(int(aws.Int64Value(targetScalingGroup.MaxSize)))
-
-	instanceTypes, err := ctx.AwsWorker.DescribeInstanceTypes()
-	if err != nil {
-		return errors.Wrap(err, "failed to discover instance types")
-	}
-	state.SetInstanceTypeInfo(instanceTypes)
 
 	if spec.IsLaunchConfiguration() {
 


### PR DESCRIPTION
Fixes #311 

This PR moves the instance type discovery above an early exit for non-provisioned IGs (https://github.com/keikoproj/instance-manager/pull/312/files#diff-d02fec8ce89d970a6731dc6003cb0f6f8c4cb452daa1ad45c5fd2691fd75afa3R187).

Signed-off-by: Jonah Back <jonah@jonahback.com>