### PR TITLE
fix: evaluate controller-added ec2 tags

### DIFF
--- a/controllers/provisioners/eks/scaling/launchconfig_test.go
+++ b/controllers/provisioners/eks/scaling/launchconfig_test.go
@@ -480,7 +480,7 @@ func TestLaunchConfigurationDrifted(t *testing.T) {
 				LaunchConfigurationName: aws.String("my-launch-config"),
 			},
 			input: &CreateConfigurationInput{
-				SecurityGroups: []string{},
+				SecurityGroups:  []string{},
 				MetadataOptions: &v1alpha1.MetadataOptions{HttpEndpoint: "enabled"},
 			},
 			shouldDrift: true,

--- a/controllers/provisioners/eks/update.go
+++ b/controllers/provisioners/eks/update.go
@@ -235,12 +235,11 @@ func (ctx *EksInstanceGroupContext) UpdateScalingGroup(configName string, scalin
 
 func (ctx *EksInstanceGroupContext) TagsUpdateNeeded() bool {
 	var (
-		instanceGroup = ctx.GetInstanceGroup()
-		configuration = instanceGroup.GetEKSConfiguration()
-		state         = ctx.GetDiscoveredState()
-		scalingGroup  = state.GetScalingGroup()
-		asgName       = aws.StringValue(scalingGroup.AutoScalingGroupName)
-		rmTags        = ctx.GetRemovedTags(asgName)
+		state        = ctx.GetDiscoveredState()
+		scalingGroup = state.GetScalingGroup()
+		asgName      = aws.StringValue(scalingGroup.AutoScalingGroupName)
+		rmTags       = ctx.GetRemovedTags(asgName)
+		addedTags    = ctx.GetAddedTags(asgName)
 	)
 
 	if len(rmTags) > 0 {
@@ -256,7 +255,11 @@ func (ctx *EksInstanceGroupContext) TagsUpdateNeeded() bool {
 		existingTags = append(existingTags, tagSet)
 	}
 
-	for _, tag := range configuration.GetTags() {
+	for _, tag := range addedTags {
+		tag := map[string]string{
+			"key":   aws.StringValue(tag.Key),
+			"value": aws.StringValue(tag.Value),
+		}
 		if !common.StringMapSliceContains(existingTags, tag) {
 			return true
 		}


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <eytan_avisror@intuit.com>
Fix #308 

This fixes a bug where controller-added tags are not evaluated when reconciling.