### PR TITLE
WIP: Initial support for custom SSM paths and IAM Roles

### DIFF
--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -36,6 +36,8 @@ const (
 	OverrideDefaultLabelsAnnotation                   = "instancemgr.keikoproj.io/default-labels"
 	IRSAEnabledAnnotation                             = "instancemgr.keikoproj.io/irsa-enabled"
 	OsFamilyAnnotation                                = "instancemgr.keikoproj.io/os-family"
+	SSMIAMRoleAnnotation                              = "instancemgr.keikoproj.io/ssm-iam-role"
+	SSMCustomPathAnnotation                           = "instancemgr.keikoproj.io/ssm-ami-path"
 	ClusterAutoscalerEnabledAnnotation                = "instancemgr.keikoproj.io/cluster-autoscaler-enabled"
 	CustomNetworkingEnabledAnnotation                 = "instancemgr.keikoproj.io/custom-networking-enabled"
 	CustomNetworkingHostPodsAnnotation                = "instancemgr.keikoproj.io/custom-networking-host-pods"

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func main() {
 		IamClient:   aws.GetAwsIamClient(awsRegion, cacheCfg, maxAPIRetries, controllerCollector),
 		AsgClient:   aws.GetAwsAsgClient(awsRegion, cacheCfg, maxAPIRetries, controllerCollector),
 		EksClient:   aws.GetAwsEksClient(awsRegion, cacheCfg, maxAPIRetries, controllerCollector),
-		SsmClient:   aws.GetAwsSsmClient(awsRegion, cacheCfg, maxAPIRetries, controllerCollector),
+		SsmClient:   aws.GetDefaultAwsSsmClient(awsRegion, cacheCfg, maxAPIRetries, controllerCollector),
 		Ec2Metadata: metadata,
 	}
 


### PR DESCRIPTION
Wanted to share some initial development and background. 
This adds support for two annotations to control the custom SSM endpoint, and IAM Role assumption.

```
apiVersion: instancemgr.keikoproj.io/v1alpha1
kind: InstanceGroup
metadata:
  annotations:
    instancemgr.keikoproj.io/ssm-iam-role: "arn:aws:iam::123456789:role/my-custom-role"
    instancemgr.keikoproj.io/ssm-ami-path: "/my/custom/ami/param"
```

This uses the aws helper `stscreds` to get new credentials. Need to test the credential refresh.
It's quite ugly using a global shared session - open to suggestions how this might work better.

