### PR TITLE
Stop passing in ClusterCA and Endpoint information for Windows nodes

### DIFF
--- a/controllers/instancegroup_controller.go
+++ b/controllers/instancegroup_controller.go
@@ -43,17 +43,18 @@ import (
 // InstanceGroupReconciler reconciles an InstanceGroup object
 type InstanceGroupReconciler struct {
 	client.Client
-	SpotRecommendationTime float64
-	ConfigNamespace        string
-	NodeRelabel            bool
-	Log                    logr.Logger
-	MaxParallel            int
-	Auth                   *InstanceGroupAuthenticator
-	ConfigMap              *corev1.ConfigMap
-	Namespaces             map[string]corev1.Namespace
-	NamespacesLock         *sync.RWMutex
-	ConfigRetention        int
-	Metrics                *common.MetricsCollector
+	SpotRecommendationTime     float64
+	ConfigNamespace            string
+	NodeRelabel                bool
+	Log                        logr.Logger
+	MaxParallel                int
+	Auth                       *InstanceGroupAuthenticator
+	ConfigMap                  *corev1.ConfigMap
+	Namespaces                 map[string]corev1.Namespace
+	NamespacesLock             *sync.RWMutex
+	ConfigRetention            int
+	Metrics                    *common.MetricsCollector
+	DisableWinClusterInjection bool
 }
 
 type InstanceGroupAuthenticator struct {
@@ -134,13 +135,14 @@ func (r *InstanceGroupReconciler) Reconcile(ctxt context.Context, req ctrl.Reque
 	r.SetFinalizer(instanceGroup)
 
 	input := provisioners.ProvisionerInput{
-		AwsWorker:       r.Auth.Aws,
-		Kubernetes:      r.Auth.Kubernetes,
-		Configuration:   r.ConfigMap,
-		InstanceGroup:   instanceGroup,
-		Log:             r.Log,
-		ConfigRetention: r.ConfigRetention,
-		Metrics:         r.Metrics,
+		AwsWorker:                  r.Auth.Aws,
+		Kubernetes:                 r.Auth.Kubernetes,
+		Configuration:              r.ConfigMap,
+		InstanceGroup:              instanceGroup,
+		Log:                        r.Log,
+		ConfigRetention:            r.ConfigRetention,
+		Metrics:                    r.Metrics,
+		DisableWinClusterInjection: r.DisableWinClusterInjection,
 	}
 
 	var (

--- a/controllers/provisioners/eks/eks.go
+++ b/controllers/provisioners/eks/eks.go
@@ -71,13 +71,14 @@ func New(p provisioners.ProvisionerInput) *EksInstanceGroupContext {
 	)
 
 	ctx := &EksInstanceGroupContext{
-		InstanceGroup:    instanceGroup,
-		KubernetesClient: p.Kubernetes,
-		AwsWorker:        p.AwsWorker,
-		Log:              p.Log.WithName("eks"),
-		ResourcePrefix:   fmt.Sprintf("%v-%v-%v", configuration.GetClusterName(), instanceGroup.GetNamespace(), instanceGroup.GetName()),
-		ConfigRetention:  p.ConfigRetention,
-		Metrics:          p.Metrics,
+		InstanceGroup:              instanceGroup,
+		KubernetesClient:           p.Kubernetes,
+		AwsWorker:                  p.AwsWorker,
+		Log:                        p.Log.WithName("eks"),
+		ResourcePrefix:             fmt.Sprintf("%v-%v-%v", configuration.GetClusterName(), instanceGroup.GetNamespace(), instanceGroup.GetName()),
+		ConfigRetention:            p.ConfigRetention,
+		Metrics:                    p.Metrics,
+		DisableWinClusterInjection: p.DisableWinClusterInjection,
 	}
 
 	ctx.SetState(v1alpha1.ReconcileInit)
@@ -89,15 +90,16 @@ func New(p provisioners.ProvisionerInput) *EksInstanceGroupContext {
 
 type EksInstanceGroupContext struct {
 	sync.Mutex
-	InstanceGroup    *v1alpha1.InstanceGroup
-	KubernetesClient kubeprovider.KubernetesClientSet
-	AwsWorker        awsprovider.AwsWorker
-	DiscoveredState  *DiscoveredState
-	Log              logr.Logger
-	Configuration    *provisioners.ProvisionerConfiguration
-	ConfigRetention  int
-	ResourcePrefix   string
-	Metrics          *common.MetricsCollector
+	InstanceGroup              *v1alpha1.InstanceGroup
+	KubernetesClient           kubeprovider.KubernetesClientSet
+	AwsWorker                  awsprovider.AwsWorker
+	DiscoveredState            *DiscoveredState
+	Log                        logr.Logger
+	Configuration              *provisioners.ProvisionerConfiguration
+	ConfigRetention            int
+	ResourcePrefix             string
+	Metrics                    *common.MetricsCollector
+	DisableWinClusterInjection bool
 }
 
 type UserDataPayload struct {

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -539,6 +539,10 @@ func (ctx *EksInstanceGroupContext) GetBootstrapArgs() string {
 	var sb strings.Builder
 	switch strings.ToLower(osFamily) {
 	case OsFamilyWindows:
+		if state.Cluster != nil && !ctx.DisableWinClusterInjection {
+			sb.WriteString(fmt.Sprintf("-Base64ClusterCA %v ", aws.StringValue(state.Cluster.CertificateAuthority.Data)))
+			sb.WriteString(fmt.Sprintf("-APIServerEndpoint %v ", aws.StringValue(state.Cluster.Endpoint)))
+		}
 		sb.WriteString(fmt.Sprintf("-KubeletExtraArgs '%v'", ctx.GetKubeletExtraArgs()))
 	case OsFamilyAmazonLinux2:
 		if bootstrapOptions != nil && bootstrapOptions.MaxPods > 0 {

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -539,10 +539,6 @@ func (ctx *EksInstanceGroupContext) GetBootstrapArgs() string {
 	var sb strings.Builder
 	switch strings.ToLower(osFamily) {
 	case OsFamilyWindows:
-		if state.Cluster != nil {
-			sb.WriteString(fmt.Sprintf("-Base64ClusterCA %v ", aws.StringValue(state.Cluster.CertificateAuthority.Data)))
-			sb.WriteString(fmt.Sprintf("-APIServerEndpoint %v ", aws.StringValue(state.Cluster.Endpoint)))
-		}
 		sb.WriteString(fmt.Sprintf("-KubeletExtraArgs '%v'", ctx.GetKubeletExtraArgs()))
 	case OsFamilyAmazonLinux2:
 		if bootstrapOptions != nil && bootstrapOptions.MaxPods > 0 {

--- a/controllers/provisioners/eks/helpers_test.go
+++ b/controllers/provisioners/eks/helpers_test.go
@@ -229,7 +229,7 @@ func TestGetBasicUserDataWindows(t *testing.T) {
     Echo "Not starting Kubelet due to warmed state."
     & C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 –Schedule
   } else {
-    & $EKSBootstrapScriptFile -EKSClusterName foo -Base64ClusterCA dGVzdA== -APIServerEndpoint foo.amazonaws.com -KubeletExtraArgs '--node-labels=foo=bar,instancemgr.keikoproj.io/image=ami-123456789012,node.kubernetes.io/role=instance-group-1 --register-with-taints=foo=bar:NoSchedule --eviction-hard=memory.available<300Mi,nodefs.available<5% --system-reserved=memory=2.5Gi --v=2 --max-pods=4' 3>&1 4>&1 5>&1 6>&1
+    & $EKSBootstrapScriptFile -EKSClusterName foo -KubeletExtraArgs '--node-labels=foo=bar,instancemgr.keikoproj.io/image=ami-123456789012,node.kubernetes.io/role=instance-group-1 --register-with-taints=foo=bar:NoSchedule --eviction-hard=memory.available<300Mi,nodefs.available<5% --system-reserved=memory=2.5Gi --v=2 --max-pods=4' 3>&1 4>&1 5>&1 6>&1
     bar
   }
 </powershell>`

--- a/controllers/provisioners/eks/helpers_test.go
+++ b/controllers/provisioners/eks/helpers_test.go
@@ -229,11 +229,88 @@ func TestGetBasicUserDataWindows(t *testing.T) {
     Echo "Not starting Kubelet due to warmed state."
     & C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 –Schedule
   } else {
+    & $EKSBootstrapScriptFile -EKSClusterName foo -Base64ClusterCA dGVzdA== -APIServerEndpoint foo.amazonaws.com -KubeletExtraArgs '--node-labels=foo=bar,instancemgr.keikoproj.io/image=ami-123456789012,node.kubernetes.io/role=instance-group-1 --register-with-taints=foo=bar:NoSchedule --eviction-hard=memory.available<300Mi,nodefs.available<5% --system-reserved=memory=2.5Gi --v=2 --max-pods=4' 3>&1 4>&1 5>&1 6>&1
+    bar
+  }
+</powershell>`
+
+	var (
+		args            = ctx.GetBootstrapArgs()
+		kubeletArgs     = ctx.GetKubeletExtraArgs()
+		userDataPayload = ctx.GetUserDataStages()
+		mounts          = ctx.GetMountOpts()
+	)
+
+	userData := ctx.GetBasicUserData("foo", args, kubeletArgs, userDataPayload, mounts)
+	basicUserDataDecoded, _ := base64.StdEncoding.DecodeString(userData)
+	basicUserDataString := string(basicUserDataDecoded)
+	if basicUserDataString != expectedDataWindows {
+		t.Fatalf("\nExpected: START>%v<END\n Got: START>%v<END", expectedDataWindows, basicUserDataString)
+	}
+}
+
+func TestGetBasicUserDataWindowsWithInjectionDisabled(t *testing.T) {
+	var (
+		k             = MockKubernetesClientSet()
+		ig            = MockInstanceGroup()
+		asgMock       = NewAutoScalingMocker()
+		iamMock       = NewIamMocker()
+		eksMock       = NewEksMocker()
+		ec2Mock       = NewEc2Mocker()
+		ssmMock       = NewSsmMocker()
+		configuration = ig.GetEKSConfiguration()
+	)
+
+	w := MockAwsWorker(asgMock, iamMock, eksMock, ec2Mock, ssmMock)
+	ctx := MockContext(ig, k, w)
+
+	configuration.BootstrapOptions = &v1alpha1.BootstrapOptions{
+		MaxPods: 4,
+	}
+	configuration.Labels = map[string]string{
+		"foo": "bar",
+	}
+	configuration.Taints = []corev1.Taint{
+		{
+			Key:    "foo",
+			Value:  "bar",
+			Effect: "NoSchedule",
+		},
+	}
+
+	configuration.BootstrapArguments = "--eviction-hard=memory.available<300Mi,nodefs.available<5% --system-reserved=memory=2.5Gi --v=2"
+	configuration.UserData = []v1alpha1.UserDataStage{
+		{
+			Stage: "PreBootstrap",
+			Data:  "foo",
+		},
+		{
+			Stage: "PostBootstrap",
+			Data:  "bar",
+		},
+	}
+
+	ig.Annotations[OsFamilyAnnotation] = OsFamilyWindows
+
+	expectedDataWindows := `
+<powershell>
+  foo
+  [string]$EKSBinDir = "$env:ProgramFiles\Amazon\EKS"
+  [string]$EKSBootstrapScriptName = 'Start-EKSBootstrap.ps1'
+  [string]$EKSBootstrapScriptFile = "$EKSBinDir\$EKSBootstrapScriptName"
+  [string]$IMDSToken=(curl -UseBasicParsing -Method PUT "http://169.254.169.254/latest/api/token" -H @{ "X-aws-ec2-metadata-token-ttl-seconds" = "21600"} | % { Echo $_.Content})
+  [string]$InstanceID=(curl -UseBasicParsing -Method GET "http://169.254.169.254/latest/meta-data/instance-id" -H @{ "X-aws-ec2-metadata-token" = "$IMDSToken"} | % { Echo $_.Content})
+  [string]$Lifecycle = Get-ASAutoScalingInstance $InstanceID | % { Echo $_.LifecycleState}
+  if ($Lifecycle -like "*Warmed*") {
+    Echo "Not starting Kubelet due to warmed state."
+    & C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 –Schedule
+  } else {
     & $EKSBootstrapScriptFile -EKSClusterName foo -KubeletExtraArgs '--node-labels=foo=bar,instancemgr.keikoproj.io/image=ami-123456789012,node.kubernetes.io/role=instance-group-1 --register-with-taints=foo=bar:NoSchedule --eviction-hard=memory.available<300Mi,nodefs.available<5% --system-reserved=memory=2.5Gi --v=2 --max-pods=4' 3>&1 4>&1 5>&1 6>&1
     bar
   }
 </powershell>`
 
+	ctx.DisableWinClusterInjection = true
 	var (
 		args            = ctx.GetBootstrapArgs()
 		kubeletArgs     = ctx.GetKubeletExtraArgs()

--- a/controllers/provisioners/provisioners.go
+++ b/controllers/provisioners/provisioners.go
@@ -27,13 +27,14 @@ const (
 )
 
 type ProvisionerInput struct {
-	AwsWorker       awsprovider.AwsWorker
-	Kubernetes      kubeprovider.KubernetesClientSet
-	InstanceGroup   *v1alpha1.InstanceGroup
-	Configuration   *corev1.ConfigMap
-	Log             logr.Logger
-	ConfigRetention int
-	Metrics         *common.MetricsCollector
+	AwsWorker                  awsprovider.AwsWorker
+	Kubernetes                 kubeprovider.KubernetesClientSet
+	InstanceGroup              *v1alpha1.InstanceGroup
+	Configuration              *corev1.ConfigMap
+	Log                        logr.Logger
+	ConfigRetention            int
+	Metrics                    *common.MetricsCollector
+	DisableWinClusterInjection bool
 }
 
 var (


### PR DESCRIPTION
The Windows EKS bootstrap script currently contains a bug related to ServiceCidr calculations when passing in ClusterCA and APIEndpoint information - see https://github.com/awslabs/amazon-eks-ami/issues/805. Until the bootstrap script allows us to provide the ServiceCIDR, we should stop passing in the ClusterCA and Endpoint information to avoid incorrect CIDRs from being calculated. 