### PR TITLE
fix: don't set max pods above kubernetes recommended limit

### DIFF
--- a/controllers/common/utils.go
+++ b/controllers/common/utils.go
@@ -256,6 +256,13 @@ func StringSliceContains(x, y []string) bool {
 	return true
 }
 
+func Min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func GetLastElementBy(s, sep string) string {
 	sp := strings.Split(s, sep)
 	return sp[len(sp)-1]

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -489,8 +489,6 @@ func (ctx *EksInstanceGroupContext) GetLabelList() []string {
 	return labelList
 }
 
-
-
 func (ctx *EksInstanceGroupContext) GetComputedBootstrapOptions() *v1alpha1.BootstrapOptions {
 	var (
 		instanceGroup = ctx.GetInstanceGroup()

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -489,12 +489,7 @@ func (ctx *EksInstanceGroupContext) GetLabelList() []string {
 	return labelList
 }
 
-func min(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
+
 
 func (ctx *EksInstanceGroupContext) GetComputedBootstrapOptions() *v1alpha1.BootstrapOptions {
 	var (
@@ -519,7 +514,7 @@ func (ctx *EksInstanceGroupContext) GetComputedBootstrapOptions() *v1alpha1.Boot
 		}
 
 		// Don't set maxPods above Kubernetes-recommended 110 per node for large clusters.
-		maxPods = min(enis*((aws.Int64Value(instanceTypeNetworkInfo.Ipv4AddressesPerInterface)-1)*ipsPerInterface) + hostNetworkPods, 110)
+		maxPods = common.Min(enis*((aws.Int64Value(instanceTypeNetworkInfo.Ipv4AddressesPerInterface)-1)*ipsPerInterface) + hostNetworkPods, 110)
 
 		if configuration.BootstrapOptions == nil {
 			return &v1alpha1.BootstrapOptions{

--- a/controllers/provisioners/eks/helpers_test.go
+++ b/controllers/provisioners/eks/helpers_test.go
@@ -403,7 +403,7 @@ func TestCustomNetworkingMaxPods(t *testing.T) {
 				CustomNetworkingEnabledAnnotation:                 "true",
 			},
 			bootstrapOptions: nil,
-			expectedMaxPods:  "--max-pods=290",
+			expectedMaxPods:  "--max-pods=110",
 		},
 		{
 			annotations: map[string]string{


### PR DESCRIPTION
Signed-off-by: Jonah Back <jonah@jonahback.com>