### PR TITLE
bug fix for launchTemplate loop reconcile

### DIFF
--- a/controllers/provisioners/eks/cloud.go
+++ b/controllers/provisioners/eks/cloud.go
@@ -238,7 +238,7 @@ func (ctx *EksInstanceGroupContext) CloudDiscovery() error {
 
 	if spec.IsLaunchTemplate() {
 		state.ScalingConfiguration, err = scaling.NewLaunchTemplate(instanceGroup.NamespacedName(), ctx.AwsWorker, &scaling.DiscoverConfigurationInput{
-			ScalingGroup: targetScalingGroup,
+			TargetConfigName: status.GetActiveLaunchTemplateName(),
 		})
 		if err != nil {
 			return errors.Wrap(err, "failed to discover launch templates")


### PR DESCRIPTION
Signed-off-by: sbadla1 <sahil_badla@intuit.com>

closes #340 

Endless LaunchTemplate creation loop happens when swtiching from launchConfig to LaunchTemplate.
Fixed the launchTemplate discovery logic to pass latest template config instead of ASG config(that still has launchConfig)