### PR TITLE
Remove spot dependency from functional test

### DIFF
--- a/test-bdd/features/01_create.feature
+++ b/test-bdd/features/01_create.feature
@@ -23,7 +23,6 @@ Feature: CRUD Create
     Given an EKS cluster
     When I create a resource instance-group.yaml
     Then the resource should be created
-    And the resource should converge to selector .status.lifecycle=spot
     And the resource should converge to selector .status.currentState=ready
     And the resource condition NodesReady should be true
     And 2 nodes should be ready
@@ -32,7 +31,6 @@ Feature: CRUD Create
     Given an EKS cluster
     When I create a resource instance-group-crd.yaml
     Then the resource should be created
-    And the resource should converge to selector .status.lifecycle=spot
     And the resource should converge to selector .status.currentState=ready
     And the resource condition NodesReady should be true
     And 2 nodes should be ready

--- a/test-bdd/templates/instance-group-crd.yaml
+++ b/test-bdd/templates/instance-group-crd.yaml
@@ -48,8 +48,5 @@ spec:
       securityGroups: {{range $element := .NodeSecurityGroups}}
         - {{$element}}
       {{ end }}
-      tags:
-      - key: k8s-minion-manager
-        value: use-spot
       metricsCollection:
       - all

--- a/test-bdd/templates/instance-group.yaml
+++ b/test-bdd/templates/instance-group.yaml
@@ -38,8 +38,5 @@ spec:
       securityGroups: {{range $element := .NodeSecurityGroups}}
         - {{$element}}
       {{ end }}
-      tags:
-      - key: k8s-minion-manager
-        value: use-spot
       metricsCollection:
       - all


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <eytan_avisror@intuit.com>

Ref #310 

Seems like most functional test failures are around failure to acquire a spot price for an instance.
It also adds a dependency on another controller (minion-manager)
This PR removes testing for spot from functional test