### PR TITLE
fix/373 Replace ARN format validation procedure

### DIFF
--- a/api/v1alpha1/instancegroup_types.go
+++ b/api/v1alpha1/instancegroup_types.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/keikoproj/instance-manager/controllers/common"
 	awsprovider "github.com/keikoproj/instance-manager/controllers/providers/aws"
 
@@ -566,10 +567,10 @@ func (c *EKSConfiguration) Validate() error {
 		if common.StringEmpty(h.Name) {
 			return errors.Errorf("validation failed, 'name' is a required parameter")
 		}
-		if !common.StringEmpty(h.NotificationArn) && !strings.HasPrefix(h.NotificationArn, awsprovider.ARNPrefix) {
+		if !common.StringEmpty(h.NotificationArn) && !arn.IsARN(h.NotificationArn) {
 			return errors.Errorf("validation failed, 'notificationArn' must be a valid IAM role ARN")
 		}
-		if !common.StringEmpty(h.RoleArn) && !strings.HasPrefix(h.NotificationArn, awsprovider.ARNPrefix) {
+		if !common.StringEmpty(h.RoleArn) && !arn.IsARN(h.NotificationArn) {
 			return errors.Errorf("validation failed, 'roleArn' must be a valid IAM role ARN")
 		}
 		hooks = append(hooks, h)
@@ -619,7 +620,7 @@ func (c *EKSConfiguration) Validate() error {
 	}
 
 	for i, v := range c.LicenseSpecifications {
-		if !strings.HasPrefix(v, awsprovider.ARNPrefix) {
+		if !arn.IsARN(v) {
 			return errors.Errorf("validation failed, 'LicenseSpecifications[%d]' must be a valid IAM role ARN", i)
 		}
 	}
@@ -643,7 +644,7 @@ func (p *PlacementSpec) Validate() error {
 		return errors.Errorf("validation failed, Tenancy must be one of default, dedicated, host")
 	}
 
-	if !common.StringEmpty(p.HostResourceGroupArn) && !strings.HasPrefix(p.HostResourceGroupArn, awsprovider.ARNPrefix) {
+	if !common.StringEmpty(p.HostResourceGroupArn) && !arn.IsARN(p.HostResourceGroupArn) {
 		return errors.Errorf("validation failed, HostResourceGroupArn must be a valid dedicated HostResourceGroup ARN")
 	}
 

--- a/controllers/providers/aws/aws.go
+++ b/controllers/providers/aws/aws.go
@@ -67,8 +67,6 @@ const (
 	LaunchTemplateAllocationStrategy        = "prioritized"
 	LaunchTemplateLatestVersionKey          = "$Latest"
 	IAMPolicyPrefix                         = "arn:aws:iam::aws:policy"
-	IAMARNPrefix                            = "arn:aws:iam::"
-	ARNPrefix                               = "arn:aws:"
 	LaunchConfigurationNotFoundErrorMessage = "Launch configuration name not found"
 	defaultPolicyArn                        = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
 )

--- a/controllers/provisioners/eks/helpers.go
+++ b/controllers/provisioners/eks/helpers.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/keikoproj/instance-manager/api/v1alpha1"
 	"github.com/keikoproj/instance-manager/controllers/common"
@@ -1027,9 +1028,7 @@ func (ctx *EksInstanceGroupContext) GetManagedPoliciesList(additionalPolicies []
 	managedPolicies := make([]string, 0)
 	for _, name := range additionalPolicies {
 		switch {
-		case strings.HasPrefix(name, awsprovider.IAMPolicyPrefix):
-			managedPolicies = append(managedPolicies, name)
-		case strings.HasPrefix(name, awsprovider.IAMARNPrefix):
+		case arn.IsARN(name):
 			managedPolicies = append(managedPolicies, name)
 		default:
 			managedPolicies = append(managedPolicies, fmt.Sprintf("%s/%s", awsprovider.IAMPolicyPrefix, name))


### PR DESCRIPTION
Fixes #373 

Feedback is welcome.

```
coverage: 83.8% of statements
ok      github.com/keikoproj/instance-manager/controllers/provisioners/eksmanaged       0.057s  coverage: 83.8% of statements
=== RUN   TestInstanceGroupSpecValidate
=== RUN   TestInstanceGroupSpecValidate/eks-fargate_with_managed_strategy
=== RUN   TestInstanceGroupSpecValidate/eks-bogus_provisioner
=== RUN   TestInstanceGroupSpecValidate/eks-fargate_with_bad_strategy
=== RUN   TestInstanceGroupSpecValidate/eks_with_empty_strings_in_licenseSpecifications
=== RUN   TestInstanceGroupSpecValidate/eks_with_invalid_licenseSpecification
=== RUN   TestInstanceGroupSpecValidate/eks_with_invalid_container_runtime
=== RUN   TestInstanceGroupSpecValidate/eks_with_valid_Placement
=== RUN   TestInstanceGroupSpecValidate/eks_with_invalid_combination_of_HostResourceGroupArn_and_Tenancy_in_Placement
=== RUN   TestInstanceGroupSpecValidate/eks_with_invalid_HostResourceGroupArn_in_Placement
=== RUN   TestInstanceGroupSpecValidate/eks_with_invalid_Tenancy_in_Placement
=== RUN   TestInstanceGroupSpecValidate/eks_with_gp3_volume_validates
=== RUN   TestInstanceGroupSpecValidate/eks_with_gp2_volume_with_provisioned_throughput_fails
=== RUN   TestInstanceGroupSpecValidate/eks_with_gp2_volume_with_provisioned_iops_fails
=== RUN   TestInstanceGroupSpecValidate/eks_with_metadataoptions_validates
=== RUN   TestInstanceGroupSpecValidate/eks_with_valid_configuration_for_any_random_partition
=== RUN   TestInstanceGroupSpecValidate/eks_with_invalid_LicenseSpecifications_for_any_random_partition
=== RUN   TestInstanceGroupSpecValidate/eks_with_invalid_combination_of_HostResourceGroupArn_and_Tenancy_in_Placement_for_any_random_partition
=== RUN   TestInstanceGroupSpecValidate/eks_with_invalid_HostResourceGroupArn_in_Placement_for_any_random_partition
--- PASS: TestInstanceGroupSpecValidate (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks-fargate_with_managed_strategy (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks-bogus_provisioner (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks-fargate_with_bad_strategy (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_empty_strings_in_licenseSpecifications (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_invalid_licenseSpecification (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_invalid_container_runtime (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_valid_Placement (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_invalid_combination_of_HostResourceGroupArn_and_Tenancy_in_Placement (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_invalid_HostResourceGroupArn_in_Placement (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_invalid_Tenancy_in_Placement (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_gp3_volume_validates (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_gp2_volume_with_provisioned_throughput_fails (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_gp2_volume_with_provisioned_iops_fails (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_metadataoptions_validates (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_valid_configuration_for_any_random_partition (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_invalid_LicenseSpecifications_for_any_random_partition (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_invalid_combination_of_HostResourceGroupArn_and_Tenancy_in_Placement_for_any_random_partition (0.00s)
    --- PASS: TestInstanceGroupSpecValidate/eks_with_invalid_HostResourceGroupArn_in_Placement_for_any_random_partition (0.00s)
=== RUN   TestLockedAnnotation
=== RUN   TestLockedAnnotation/Locked
=== RUN   TestLockedAnnotation/Unlocked
--- PASS: TestLockedAnnotation (0.00s)
    --- PASS: TestLockedAnnotation/Locked (0.00s)
    --- PASS: TestLockedAnnotation/Unlocked (0.00s)
PASS
coverage: 13.0% of statements
ok      github.com/keikoproj/instance-manager/api/v1alpha1      0.074s  coverage: 13.0% of statements
go build -o bin/manager main.go

```