### PR TITLE
Fix GitHub Container Registry Authentication

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -1,7 +1,4 @@
-name: image-push
-permissions:
-  contents: read
-  packages: write
+name: Create and publish a Docker image
 
 on:
   push:
@@ -10,8 +7,8 @@ on:
     - "v*.*.*"
 
 jobs:
-  build:
-    name: Build
+  build-image:
+    name: Build Image
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -59,7 +56,12 @@ jobs:
   merge-and-push:
     name: Merge and Push
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-image
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     if: github.event_name != 'pull_request'
     steps:
       - name: Set up Docker Buildx
@@ -93,8 +95,23 @@ jobs:
             org.opencontainers.image.version={{version}}
             
       - name: Create manifest list and push
+        id: push
         uses: docker/build-push-action@v6
         with:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+
+      - name: Generate artifact attestation (dockerhub)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ github.repository_owner }}/instance-manager
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate artifact attestation (ghcr)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/instance-manager
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary
This PR resolves authentication issues with GitHub Container Registry (GHCR) in our Docker image build workflow.

## Changes

### Authentication Fixes
- Improved authentication with GitHub Container Registry using appropriate credentials
- Updated container registry permissions in the workflow configuration
- Fixed build provenance attestation to properly work with both registries

## Context
The previous image build improvements (PR #475) were unable to properly authenticate with GHCR, resulting in 403 Forbidden errors when attempting to push images. This PR specifically addresses those authentication issues.

## Testing
The workflow has been tested to verify:
1. Proper authentication with both DockerHub and GitHub Container Registry
2. Correct image tagging and pushing to both registries
3. Generation of build provenance attestations

## Related PRs
Builds on and fixes issues introduced in PR #475