### PR TITLE
Fix Docker Registry Authentication in GitHub Actions

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -30,7 +30,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.repository_owner }}/instance-manager,ghcr.io/${{ github.repository_owner }}/instance-manager
+          images: docker.io/${{ github.repository_owner }}/instance-manager,ghcr.io/${{ github.repository_owner }}/instance-manager
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -49,7 +49,7 @@ jobs:
           push: false
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          outputs: type=image,name=${{ github.repository_owner }}/instance-manager,push-by-digest=true,name-canonical=true,push=false
+          outputs: type=image,name=docker.io/${{ github.repository_owner }}/instance-manager,push-by-digest=true,name-canonical=true,push=false
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -87,7 +87,7 @@ jobs:
         id: metadata
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.repository_owner }}/instance-manager,ghcr.io/${{ github.repository_owner }}/instance-manager
+          images: docker.io/${{ github.repository_owner }}/instance-manager,ghcr.io/${{ github.repository_owner }}/instance-manager
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -108,7 +108,7 @@ jobs:
       - name: Generate artifact attestation (dockerhub)
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ github.repository_owner }}/instance-manager
+          subject-name: docker.io/${{ github.repository_owner }}/instance-manager
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes the image-push workflow that was failing with the error "No credentials found for registry keikoproj". The issue was caused by not explicitly specifying the Docker registry, causing Docker to interpret "keikoproj" as a registry name rather than an organization on DockerHub.

### Changes made
- Added explicit `docker.io/` prefix to all Docker image references in the workflow
- Updated build outputs configuration to use the fully qualified image name
- Updated attestation subject names to use consistent registry references

### How to verify it
The image-push GitHub Action workflow should now successfully authenticate and push images to both DockerHub and GitHub Container Registry.