### PR TITLE
Fix Docker Registry Authentication and Multi-arch Image Annotations

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -115,10 +115,22 @@ jobs:
         id: push
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
+          provenance: false
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          annotations: ${{ steps.metadata.outputs.labels }}
+          outputs: |
+            type=registry
+            annotation-index.org.opencontainers.image.description=A Kubernetes controller for creating and managing worker node instance groups across multiple providers
+            annotation-index.org.opencontainers.image.licenses=Apache-2.0
+            annotation-index.org.opencontainers.image.source=https://github.com/keikoproj/instance-manager
+            annotation-index.org.opencontainers.image.url=https://github.com/keikoproj/instance-manager/blob/master/README.md
+            annotation-index.org.opencontainers.image.vendor=keikoproj
+            annotation-index.org.opencontainers.image.authors=Keikoproj Contributors
+            annotation-index.org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            annotation-index.org.opencontainers.image.version=${{ github.ref_name }}
+            annotation-index.org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Generate artifact attestation (dockerhub)
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
### What this PR does / why we need it
This PR addresses two issues with the container image workflow:

1. **Registry Authentication**: Fixes the image-push workflow that was failing with the error "No credentials found for registry keikoproj" by explicitly specifying the Docker registry.

2. **Multi-arch Image Annotations**: Adds proper annotations to multi-architecture container images using the correct `annotation-index` syntax, addressing the GitHub Packages warning about missing image description.

### Changes made
- Added explicit `docker.io/` prefix to all Docker image references
- Implemented the recommended `annotation-index` syntax for multi-arch manifests
- Added comprehensive OCI annotations (description, license, source, etc.)
- Disabled duplicate provenance to avoid conflicts with the dedicated attestation actions

### How to verify it
- The image-push GitHub Action workflow should now successfully authenticate
- Multi-arch images should display proper metadata in GitHub Packages including description
- SLSA attestations should be correctly generated for both DockerHub and GitHub Container Registry
