### PR TITLE
fix: add back file pointing to dockerfile

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -118,6 +118,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ./Dockerfile
           push: true
           provenance: false
           tags: ${{ steps.metadata.outputs.tags }}


### PR DESCRIPTION
### Root Cause
In the `merge-and-push` job, the `docker/build-push-action@v6` step was missing the `file: ./Dockerfile` parameter that specifies the location of the Dockerfile. This parameter was correctly specified in the `build-image` job but was missing in the final push step.

### Solution
Added the missing `file: ./Dockerfile` parameter to the `Create manifest list and push` step in the `merge-and-push` job, allowing the action to locate the Dockerfile during the build process.

### Testing
- This change can be verified when the workflow runs on this branch
