### PR TITLE
fix: add checkout step to merge-and-push job in workflow

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -75,6 +75,9 @@ jobs:
       id-token: write      # For OIDC token authentication
     if: github.event_name != 'pull_request'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         


### PR DESCRIPTION
## Fix Docker image build in GitHub Actions workflow

### Issue
The GitHub Actions workflow to build and push Docker images was failing with the error:

```
ERROR: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

### Root Cause
The `merge-and-push` job was missing the `actions/checkout@v4` step, so the repository content (including the Dockerfile) wasn't available in this job's runner environment. In GitHub Actions, each job runs in a completely fresh environment, requiring explicit repository checkout.

### Solution
Added the `actions/checkout@v4` step to the beginning of the `merge-and-push` job to ensure the Dockerfile and other repository files are available during the Docker build process.

### Testing
This change can be verified when the workflow runs on this branch.