### PR TITLE
ci: use repo name variable and add release update in image-push workflow

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -1,7 +1,9 @@
 name: Create and publish image
 permissions:
-  contents: read         # Needed to check out the repository
+  contents: write        # Needed to check out the repository and update releases
   packages: write        # Needed to push images to GitHub Container Registry (ghcr.io)
+  attestations: write    # For generating attestations
+  id-token: write        # For OIDC token authentication
 
 on:
   push:
@@ -13,11 +15,6 @@ jobs:
   build-and-push:
     name: Build and push image
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      attestations: write  # For generating attestations
-      id-token: write      # For OIDC token authentication
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout

--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -38,7 +38,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: docker.io/${{ github.repository_owner }}/instance-manager,ghcr.io/${{ github.repository_owner }}/instance-manager
+          images: docker.io/${{ github.repository_owner }}/${{ github.event.repository.name }},ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -83,13 +83,32 @@ jobs:
       - name: Generate artifact attestation (dockerhub)
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: docker.io/${{ github.repository_owner }}/instance-manager
+          subject-name: docker.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
       - name: Generate artifact attestation (ghcr)
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ghcr.io/${{ github.repository_owner }}/instance-manager
+          subject-name: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Update GitHub Release with image and attestation links
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          append_body: true
+          body: |
+            ## Docker Images
+            - [DockerHub](https://hub.docker.com/r/${{ github.repository_owner }}/${{ github.event.repository.name }}/tags?name=${{ github.ref_name }})
+            - [GHCR](https://github.com/orgs/${{ github.repository_owner }}/packages/container/${{ github.event.repository.name }})
+            - `docker pull ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}`
+            - `docker pull ${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}`
+
+            ## Attestations
+            - DockerHub attestation for `${{ github.ref_name }}` published (see OCI provenance)
+            - GHCR attestation for `${{ github.ref_name }}` published (see OCI provenance)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the `.github/workflows/image-push.ym`l workflow to:
- Use the `${{ github.event.repository.name }}` variable instead of the hardcoded `instance-manager` string, making the workflow portable and reusable.
- Add a step with `softprops/action-gh-release` to automatically update the GitHub Release with Docker image links and attestation information for release tags.

**Why?**
- Easier to copy and maintain workflows across multiple repos.
- Reduces risk of copy-paste errors.
- Improves release transparency and user experience.