### PR TITLE
fix: update GHA runner image to ubuntu-latest

### DIFF
--- a/.github/workflows/functional-test.yaml
+++ b/.github/workflows/functional-test.yaml
@@ -14,7 +14,7 @@ jobs:
   functional-test:
     name: functional-test
     if: false               # Disable the workflow since AWS test environment has been removed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
   unit-test:
     if: github.repository_owner == 'keikoproj'
     name: unit-test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5


### PR DESCRIPTION
This PR updates the runner image for all relevant GitHub Actions workflows to use `ubuntu-latest` instead of the deprecated `ubuntu-20.04`.

See https://github.com/actions/runner-images/issues/11101 for more details.

## Changes
- `.github/workflows/unit-test.yml`: `runs-on` updated from `ubuntu-20.04` to `ubuntu-latest`
- .`github/workflows/functional-test.yaml`: `runs-on` updated from `ubuntu-20.04` to `ubuntu-latest` (if previously present; now confirmed as `ubuntu-latest`)

## Why?
- [GitHub Actions is deprecating the ubuntu-20.04 runner image](https://github.com/actions/runner-images/issues/11101)
- Ensures continued support and security updates for CI workflows
- Follows best practices for open-source and Kubernetes-related projects