### PR TITLE
fix: use Docker metadata-action tag for release notes

### DIFF
--- a/.github/workflows/image-push.yml
+++ b/.github/workflows/image-push.yml
@@ -43,6 +43,14 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
 
+      # Extract primary Docker tag (without 'v')
+      - name: Extract primary Docker tag
+        id: docker_tag
+        run: |
+          TAGS="${{ steps.meta.outputs.tags }}"
+          PRIMARY_TAG=$(echo "$TAGS" | cut -d',' -f1)
+          echo "tag=$PRIMARY_TAG" >> $GITHUB_OUTPUT
+
       # Login to DockerHub
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -99,13 +107,13 @@ jobs:
           append_body: true
           body: |
             ## Docker Images
-            - [DockerHub](https://hub.docker.com/r/${{ github.repository_owner }}/${{ github.event.repository.name }}/tags?name=${{ github.ref_name }})
+            - [DockerHub](https://hub.docker.com/r/${{ github.repository_owner }}/${{ github.event.repository.name }}/tags?name=${{ steps.docker_tag.outputs.tag }})
             - [GHCR](https://github.com/orgs/${{ github.repository_owner }}/packages/container/${{ github.event.repository.name }})
-            - `docker pull ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}`
-            - `docker pull ${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ github.ref_name }}`
+            - `docker pull ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.docker_tag.outputs.tag }}`
+            - `docker pull ${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ steps.docker_tag.outputs.tag }}`
 
             ## Attestations
-            - DockerHub attestation for `${{ github.ref_name }}` published (see OCI provenance)
-            - GHCR attestation for `${{ github.ref_name }}` published (see OCI provenance)
+            - DockerHub attestation for `${{ steps.docker_tag.outputs.tag }}` published (see OCI provenance)
+            - GHCR attestation for `${{ steps.docker_tag.outputs.tag }}` published (see OCI provenance)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Use Docker Metadata Tag for Release Notes

This PR updates the image-push.yml workflow to ensure that Docker image links, pull commands, and attestation references in GitHub Release notes use the correct Docker tag (without the "v" prefix).

## What Changed

- **Added a step** to extract the primary Docker tag from the output of `docker/metadata-action` (which automatically strips the "v" from tags like `v0.19.0` to produce `0.19.0`).
- **Updated the release notes** (via `softprops/action-gh-release`) to use this tag for:
  - DockerHub and GHCR links
  - Example `docker pull` commands
  - Attestation references

## Why?

- Previously, the release notes used `${{ github.ref_name }}` which included the "v" prefix (e.g., `v0.19.0`), resulting in incorrect pull commands and links.
- This change ensures users always see accurate instructions and links that match the actual published Docker images.

## References

- [docker/metadata-action documentation](https://github.com/docker/metadata-action)
- [Example release showing the issue](https://github.com/keikoproj/instance-manager/releases)
