### PR TITLE
fix: launchtemplates disable InstanceMetadataTags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ vendor/*
 *.idea
 .windsurfrules
 .qodo
+.tool-versions

--- a/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
+++ b/config/crd/bases/instancemgr.keikoproj.io_instancegroups.yaml
@@ -78,8 +78,6 @@ spec:
                 properties:
                   configuration:
                     properties:
-                      nodeConfig:
-                        type: string
                       bootstrapArguments:
                         type: string
                       bootstrapOptions:

--- a/controllers/provisioners/eks/scaling/launchtemplate.go
+++ b/controllers/provisioners/eks/scaling/launchtemplate.go
@@ -364,6 +364,7 @@ func (lt *LaunchTemplate) metadataOptions(input *v1alpha1.MetadataOptions) *ec2.
 		HttpEndpoint:            aws.String(input.HttpEndpoint),
 		HttpPutResponseHopLimit: aws.Int64(input.HttpPutHopLimit),
 		HttpTokens:              aws.String(input.HttpTokens),
+		InstanceMetadataTags:    aws.String("disabled"), // set disabled by default
 	}
 }
 
@@ -375,6 +376,7 @@ func (lt *LaunchTemplate) metadataOptionsRequest(input *v1alpha1.MetadataOptions
 		HttpEndpoint:            aws.String(input.HttpEndpoint),
 		HttpPutResponseHopLimit: aws.Int64(input.HttpPutHopLimit),
 		HttpTokens:              aws.String(input.HttpTokens),
+		InstanceMetadataTags:    aws.String("disabled"), // set disabled by default
 	}
 }
 


### PR DESCRIPTION
## What type of PR is this?
<!-- Please check all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature/Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Dependency upgrade

## Description
Fixes issue where IGs using LaunchTemplates may inherit `InstanceMetadataTags="enabled"` property as an account setting but it won't work for Kubernetes Nodes due to a restriction of using "/" characters which conflicts with kubernetes.io/cluster/<clustername> tagging.

This change will always set `InstanceMetadataTags` as "disabled"

## Related issue(s)
<!-- Please link the issue being fixed, e.g. Fixes #123 -->

## High-level overview of changes
<!-- 
Provide a high-level description of what changes were made and why.
This helps reviewers understand your approach.
-->

## Testing performed
<!-- 
Describe the testing you've done:
- Unit tests added/modified
- Integration tests
- Manual testing performed 
- Any test outputs/results
-->

## Checklist
<!-- Please check all that apply -->

- [ ] I've read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I've added/updated tests that prove my fix is effective or that my feature works
- [ ] I've added necessary documentation (if appropriate)
- [ ] I've run `make test` locally and all tests pass
- [ ] I've signed-off my commits with `git commit -s` for DCO verification
- [ ] I've updated any relevant documentation
- [ ] Code follows the style guidelines of this project

## Additional information
<!--
Any other information that is important to this PR, such as screenshots 
of how the component looks before and after the change.
-->
