### PR TITLE
feat: change keypairName as optional parameter for instance group

### DIFF
--- a/api/instancemgr/v1alpha1/instancegroup_types.go
+++ b/api/instancemgr/v1alpha1/instancegroup_types.go
@@ -591,9 +591,6 @@ func (c *EKSConfiguration) Validate() error {
 	if common.StringEmpty(c.InstanceType) {
 		return errors.Errorf("validation failed, 'instanceType' is a required parameter")
 	}
-	if common.StringEmpty(c.KeyPairName) {
-		return errors.Errorf("validation failed, 'keyPair' is a required parameter")
-	}
 
 	for _, v := range c.Volumes {
 

--- a/api/instancemgr/v1alpha1/instancegroup_types_test.go
+++ b/api/instancemgr/v1alpha1/instancegroup_types_test.go
@@ -158,6 +158,24 @@ func TestInstanceGroupSpecValidate(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "eks without keyPairName",
+			args: args{
+				instancegroup: MockInstanceGroup("eks", "rollingUpdate", &EKSSpec{
+					MaxSize: 1,
+					MinSize: 1,
+					Type:    "LaunchTemplate",
+					EKSConfiguration: &EKSConfiguration{
+						EksClusterName:     "my-eks-cluster",
+						NodeSecurityGroups: []string{"sg-123456789"},
+						Image:              "ami-12345",
+						InstanceType:       "m5.large",
+						Subnets:            []string{"subnet-1111111", "subnet-222222"},
+					},
+				}, nil, nil),
+			},
+			want: "",
+		},
+		{
 			name: "eks with invalid combination of HostResourceGroupArn and Tenancy in Placement",
 			args: args{
 				instancegroup: MockInstanceGroup("eks", "rollingUpdate", &EKSSpec{

--- a/controllers/providers/aws/eks.go
+++ b/controllers/providers/aws/eks.go
@@ -140,10 +140,6 @@ func (w *AwsWorker) CreateManagedNodeGroup() error {
 		NodeRole:       aws.String(w.Parameters["NodeRole"].(string)),
 		NodegroupName:  aws.String(w.Parameters["NodegroupName"].(string)),
 		ReleaseVersion: aws.String(w.Parameters["ReleaseVersion"].(string)),
-		RemoteAccess: &eks.RemoteAccessConfig{
-			Ec2SshKey:            aws.String(w.Parameters["Ec2SshKey"].(string)),
-			SourceSecurityGroups: aws.StringSlice(w.Parameters["SourceSecurityGroups"].([]string)),
-		},
 		ScalingConfig: &eks.NodegroupScalingConfig{
 			MaxSize:     aws.Int64(w.Parameters["MaxSize"].(int64)),
 			MinSize:     aws.Int64(w.Parameters["MinSize"].(int64)),
@@ -152,6 +148,13 @@ func (w *AwsWorker) CreateManagedNodeGroup() error {
 		Subnets: aws.StringSlice(w.Parameters["Subnets"].([]string)),
 		Tags:    aws.StringMap(w.compactTags(w.Parameters["Tags"].([]map[string]string))),
 		Version: aws.String(w.Parameters["Version"].(string)),
+	}
+
+	if sshKey, ok := w.Parameters["Ec2SshKey"].(string); ok && sshKey != "" {
+		input.RemoteAccess = &eks.RemoteAccessConfig{
+			Ec2SshKey:            aws.String(sshKey),
+			SourceSecurityGroups: aws.StringSlice(w.Parameters["SourceSecurityGroups"].([]string)),
+		}
 	}
 
 	_, err := w.EksClient.CreateNodegroup(input)

--- a/controllers/provisioners/eks/scaling/interface.go
+++ b/controllers/provisioners/eks/scaling/interface.go
@@ -16,6 +16,7 @@ limitations under the License.
 package scaling
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/keikoproj/instance-manager/api/instancemgr/v1alpha1"
@@ -76,4 +77,11 @@ func ConvertToLaunchConfiguration(resource interface{}) *autoscaling.LaunchConfi
 		return lc
 	}
 	return &autoscaling.LaunchConfiguration{}
+}
+
+func optionalKeyName(keyName string) *string {
+	if keyName == "" {
+		return nil
+	}
+	return aws.String(keyName)
 }

--- a/controllers/provisioners/eks/scaling/launchconfig.go
+++ b/controllers/provisioners/eks/scaling/launchconfig.go
@@ -85,7 +85,7 @@ func (lc *LaunchConfiguration) Create(input *CreateConfigurationInput) error {
 		IamInstanceProfile:      aws.String(input.IamInstanceProfileArn),
 		ImageId:                 aws.String(input.ImageId),
 		InstanceType:            aws.String(input.InstanceType),
-		KeyName:                 aws.String(input.KeyName),
+		KeyName:                 optionalKeyName(input.KeyName),
 		SecurityGroups:          aws.StringSlice(input.SecurityGroups),
 		UserData:                aws.String(input.UserData),
 		BlockDeviceMappings:     devices,

--- a/controllers/provisioners/eks/scaling/launchtemplate.go
+++ b/controllers/provisioners/eks/scaling/launchtemplate.go
@@ -96,7 +96,7 @@ func (lt *LaunchTemplate) Create(input *CreateConfigurationInput) error {
 		},
 		ImageId:               aws.String(input.ImageId),
 		InstanceType:          aws.String(input.InstanceType),
-		KeyName:               aws.String(input.KeyName),
+		KeyName:               optionalKeyName(input.KeyName),
 		SecurityGroupIds:      aws.StringSlice(input.SecurityGroups),
 		UserData:              aws.String(input.UserData),
 		BlockDeviceMappings:   lt.blockDeviceListRequest(input.Volumes),

--- a/controllers/provisioners/eksmanaged/eksmanaged.go
+++ b/controllers/provisioners/eksmanaged/eksmanaged.go
@@ -252,7 +252,9 @@ func (ctx *EksManagedInstanceGroupContext) processParameters() {
 	params["NodegroupName"] = instanceGroup.GetName()
 	params["ReleaseVersion"] = configuration.ReleaseVersion
 	params["Version"] = configuration.Version
-	params["Ec2SshKey"] = configuration.KeyPairName
+	if configuration.KeyPairName != "" {
+		params["Ec2SshKey"] = configuration.KeyPairName
+	}
 	params["SourceSecurityGroups"] = configuration.NodeSecurityGroups
 	params["Subnets"] = configuration.Subnets
 	params["Tags"] = configuration.Tags


### PR DESCRIPTION
<!-- 
Please make sure you've read and understood our contributing guidelines.
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide the following information:
-->

## What type of PR is this?
<!-- Please check all that apply -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature/Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Dependency upgrade

## Description
<!-- Please explain the changes you made here. -->
`keyPairName` is currently a required field on `EKSConfiguration`, forcing every
InstanceGroup to specify an EC2 key pair even when SSH access via key pairs is
not desired (e.g. clusters that rely solely on SSM/IMDSv2 for node access).
This PR makes `keyPairName` optional and ensures the field is omitted from the
underlying AWS API calls (launch templates, launch configurations, and managed
node groups) when not set, instead of sending an empty string.

## Related issue(s)
<!-- Please link the issue being fixed, e.g. Fixes #123 -->

## High-level overview of changes
<!-- 
Provide a high-level description of what changes were made and why.
This helps reviewers understand your approach.
-->
- Removed the `'keyPair' is a required parameter` validation in
  `EKSConfiguration.Validate()`.
- `scaling.LaunchTemplate.Create()` / `scaling.LaunchConfiguration.Create()` now
  use a new `optionalKeyName()` helper that returns `nil` instead of
  `aws.String("")` when no key pair is configured, so `KeyName` is omitted from
  the EC2 API request rather than sent as an empty string.
- `eksmanaged.processParameters()` only sets the `Ec2SshKey` parameter when
  `KeyPairName` is non-empty.
- `AwsWorker.CreateManagedNodeGroup()` only attaches a `RemoteAccessConfig`
  (with `Ec2SshKey` / `SourceSecurityGroups`) when an SSH key parameter is
  present, since EKS managed node groups reject `RemoteAccess` without a valid
  key.
- Drift detection logic (`Drifted()` in launch template/config) is unaffected:
  it already compares via `aws.StringValue(...)`, which treats a `nil` AWS
  response field the same as an empty string.

## Testing performed
<!-- 
Describe the testing you've done:
- Unit tests added/modified
- Integration tests
- Manual testing performed 
- Any test outputs/results
-->
- Added a new validation test case (`"eks without keyPairName"`) confirming
  `EKSConfiguration.Validate()` succeeds without `keyPairName` set.
- Ran the full unit test suite for affected packages:
  `api/instancemgr/v1alpha1`, `controllers/provisioners/eks`,
  `controllers/provisioners/eks/scaling`, `controllers/provisioners/eksmanaged`,
  `controllers/providers/aws` — all passing.
- Manually verified against a local IKS cluster previously failing with
  `validation failed, 'keyPair' is a required parameter`.

## Checklist
<!-- Please check all that apply -->

- [x] I've read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I've added/updated tests that prove my fix is effective or that my feature works
- [ ] I've added necessary documentation (if appropriate)
- [x] I've run `make test` locally and all tests pass
- [ ] I've signed-off my commits with `git commit -s` for DCO verification
- [ ] I've updated any relevant documentation
- [x] Code follows the style guidelines of this project

## Additional information
<!--
Any other information that is important to this PR, such as screenshots 
of how the component looks before and after the change.
-->
This is a backward-compatible change: InstanceGroups that already specify
`keyPairName` continue to work unchanged. Existing CRDs/templates that still
pass `keyPairName` are unaffected; it simply becomes optional going forward.
