### PR TITLE
feat: enhancing AWS provider GetDNSClusterIP for IPv6

### DIFF
--- a/controllers/providers/aws/eks.go
+++ b/controllers/providers/aws/eks.go
@@ -16,6 +16,7 @@ limitations under the License.
 package aws
 
 import (
+	"net"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -217,14 +218,41 @@ func (w *AwsWorker) DescribeFargateProfile() (*eks.FargateProfile, error) {
 }
 
 func (w *AwsWorker) GetDNSClusterIP(cluster *eks.Cluster) string {
-	if cluster == nil {
+	if cluster == nil || cluster.KubernetesNetworkConfig == nil {
 		return ""
 	}
-	serviceCidr := aws.StringValue(cluster.KubernetesNetworkConfig.ServiceIpv4Cidr)
+	netCfg := cluster.KubernetesNetworkConfig
+
+	// IPv6 clusters populate ServiceIpv6Cidr and leave ServiceIpv4Cidr empty.
+	// The DNS service IP is the service CIDR's network address with its last
+	// byte set to 0x0a ("::a"), e.g. fd31:8cc0:942b::/108 -> fd31:8cc0:942b::a,
+	// mirroring the IPv4 ".10" convention below.
+	if serviceCidrV6 := aws.StringValue(netCfg.ServiceIpv6Cidr); serviceCidrV6 != "" {
+		prefix := strings.Split(serviceCidrV6, "/")[0] // remove block size
+		ip := net.ParseIP(prefix)
+		if ip == nil {
+			return ""
+		}
+		ip = ip.To16()
+		if ip == nil {
+			return ""
+		}
+		dnsIP := make(net.IP, len(ip))
+		copy(dnsIP, ip)
+		dnsIP[len(dnsIP)-1] = 0x0a // last byte "10", as is the convention
+		return dnsIP.String()
+	}
+
+	serviceCidr := aws.StringValue(netCfg.ServiceIpv4Cidr)
 	// addresses are by default assigned from either the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks.
 	// custom ranges could be blocks that are not /16 size.
 	ip := strings.Split(serviceCidr, "/")[0] // remove block size
 	blocks := strings.Split(ip, ".")
+	if len(blocks) != 4 {
+		// not an IPv4 dotted-quad (e.g. empty or malformed); avoid an
+		// index-out-of-range panic and let the caller omit --dns-cluster-ip.
+		return ""
+	}
 	blocks[3] = "10" // replace last byte in IP address with "10" as is the convention
 	return strings.Join(blocks, ".")
 }

--- a/controllers/providers/aws/eks_test.go
+++ b/controllers/providers/aws/eks_test.go
@@ -16,4 +16,17 @@ func TestClusterDns(t *testing.T) {
 	ip := awsWorker.GetDNSClusterIP(&eks.Cluster{KubernetesNetworkConfig: &eks.KubernetesNetworkConfigResponse{ServiceIpv4Cidr: &cidr}})
 	g.Expect(ip).To(gomega.Equal("172.16.0.10"))
 
+	// IPv6 cluster: ServiceIpv4Cidr is empty, ServiceIpv6Cidr is set.
+	// DNS IP is the service CIDR network address with the last byte as 0x0a.
+	cidrV6 := "fd31:8cc0:942b::/108"
+	ipV6 := awsWorker.GetDNSClusterIP(&eks.Cluster{KubernetesNetworkConfig: &eks.KubernetesNetworkConfigResponse{ServiceIpv6Cidr: &cidrV6}})
+	g.Expect(ipV6).To(gomega.Equal("fd31:8cc0:942b::a"))
+
+	// Malformed/empty service CIDR must not panic; caller omits --dns-cluster-ip.
+	empty := ""
+	ipEmpty := awsWorker.GetDNSClusterIP(&eks.Cluster{KubernetesNetworkConfig: &eks.KubernetesNetworkConfigResponse{ServiceIpv4Cidr: &empty}})
+	g.Expect(ipEmpty).To(gomega.Equal(""))
+
+	// nil network config must not panic.
+	g.Expect(awsWorker.GetDNSClusterIP(&eks.Cluster{})).To(gomega.Equal(""))
 }


### PR DESCRIPTION
closes #562 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Feature/Enhancement (non-breaking change which adds functionality)

## Description
GetDNSClusterIP derives the cluster DNS IP by the standard EKS convention—the 10th address of the service CIDR (network address + 10: IPv4's .10, IPv6's ::a)—but it only reads ServiceIpv4Cidr and computes this via dotted-quad string math (strings.Split(ip, ".")[3]), so on an IPv6 EKS cluster, where ServiceIpv4Cidr is empty and ServiceIpv6Cidr is set instead, it panics with index out of range [3] with length 1 and crashes every InstanceGroup reconcile before any status is written. This makes the derivation IPv6-aware (parse ServiceIpv6Cidr and return the service CIDR's network address with its last byte set to 0x0a) and adds guards so a malformed or empty CIDR returns "" instead of panicking. Verified against a live IPv6 cluster (fd31:8cc0:942b::/108 → fd31:8cc0:942b::a, matching the actual kube-dns ClusterIP) with unit tests covering the IPv6, empty-CIDR, and nil-config cases.

## Testing performed
- [x] Unit tests added with values from live cluster

## Checklist
<!-- Please check all that apply -->

- [x] I've read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I've added/updated tests that prove my fix is effective or that my feature works
- [x] I've added necessary documentation (if appropriate)
- [x] I've run `make test` locally and all tests pass
- [x] I've signed-off my commits with `git commit -s` for DCO verification
- [x] I've updated any relevant documentation
- [x] Code follows the style guidelines of this project
