### PR TITLE
ci: pin golangci-lint to go.mod to fix Go 1.27 toolchain panic

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,11 @@ on:
     branches: [ "master" ]
 
 env:
-  GO_VERSION: stable
+  # Pin Go to go.mod, not "stable". Prebuilt golangci-lint binaries cannot
+  # load a newer GOROOT than they were compiled with (v2.11.4 is Go 1.26).
+  # Using stable=go1.27 caused: panic: file requires newer Go version go1.27
+  # (application built with go1.26). Bump GOLANGCI_LINT_VERSION when go.mod
+  # advances past the Go version used to build the pinned linter.
   GOLANGCI_LINT_VERSION: v2.11.4
 
 jobs:
@@ -21,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - id: set-modules
         run: echo "modules=$(go list -m -json | jq -s '.' | jq -c '[.[].Dir]')" >> $GITHUB_OUTPUT
 
@@ -35,7 +39,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - name: golangci-lint ${{ matrix.modules }}
         uses: golangci/golangci-lint-action@v9
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What type of PR is this?
<!-- Please check all that apply -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature/Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Dependency upgrade

## Description

The `golangci-lint` check is failing on current `master` (and therefore on Dependabot PRs such as #570, #572, #566, and #564) with:

```
panic: file requires newer Go version go1.27 (application built with go1.26)
##[error]golangci-lint exit with code 2
```

This is **not** caused by the dependency bumps. Unit tests, DCO, and `detect-modules` still pass.

## Root cause

`.github/workflows/golangci-lint.yml` used `GO_VERSION: stable` with a pinned `golangci-lint` **v2.11.4**.

- `actions/setup-go` now resolves `stable` to **Go 1.27.1**
- The prebuilt golangci-lint v2.11.4 binary was compiled with **Go 1.26**
- Package loading then panics because GOROOT/stdlib files require go1.27

`go.mod` is `go 1.26.0` and the Dockerfile is `golang:1.26-alpine`. The unit-test workflow already uses `go-version: ^1.26` and is unaffected — only the prebuilt linter binary is sensitive to this skew.

Same root cause and fix as keikoproj/upgrade-manager#576.

## Why pin Go instead of bumping the linter

golangci-lint **v2.13.0** added Go 1.27 support. Bumping the linter and keeping `GO_VERSION: stable` would fix today's panic, but the same failure returns the next time `stable` advances (e.g. Go 1.28) while the linter binary lags.

Pinning the lint job to `go-version-file: go.mod`:

- Keeps GOROOT aligned with the project's declared toolchain (1.26)
- Matches the Dockerfile
- Does not recur when GitHub's `stable` alias moves
- Avoids a linter minor bump that could introduce new findings

When `go.mod` later advances past the Go version used to build the pinned linter, bump `GOLANGCI_LINT_VERSION` in the same change.

## Related issue(s)

Unblocks Dependabot PRs blocked by the lint panic (#570, #572, #566, #564).

## High-level overview of changes

- Replace `go-version: ${{ env.GO_VERSION }}` / `GO_VERSION: stable` with `go-version-file: go.mod` in both `setup-go` steps
- Leave `GOLANGCI_LINT_VERSION: v2.11.4` unchanged
- Remove unused `GO_VERSION` env

## Testing performed

- [x] Confirmed go.mod (`1.26.0`) and Dockerfile (`golang:1.26-alpine`) already declare Go 1.26
- [x] Confirmed the same panic on Dependabot PR #570 (`golangci-lint` failed; `unit-test` and `detect-modules` passed)
- [x] Confirmed same pattern/fix as keikoproj/upgrade-manager#576
- [x] `golangci-lint` workflow passes on this PR (Go 1.26, no build-version panic)
- [x] `unit-test` still passes

All 7 CI checks on this PR succeeded: DCO, detect-modules, golangci-lint, unit-test, CodeQL, Analyze (go), Analyze (actions).

## Checklist
<!-- Please check all that apply -->

- [x] I've read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I've added/updated tests that prove my fix is effective or that my feature works
- [ ] I've added necessary documentation (if appropriate)
- [ ] I've run `make test` locally and all tests pass
- [x] I've signed-off my commits with `git commit -s` for DCO verification
- [ ] I've updated any relevant documentation
- [x] Code follows the style guidelines of this project

## Additional information

Workflow-only change. CI on this PR is the verification that the panic is gone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41f4768f-ffca-47fc-b4b8-0479cf76c06c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41f4768f-ffca-47fc-b4b8-0479cf76c06c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

